### PR TITLE
Removed path typecasting in agtype parser

### DIFF
--- a/regress/expected/agtype.out
+++ b/regress/expected/agtype.out
@@ -1854,15 +1854,6 @@ SELECT agtype_hash_cmp('
       -231467898
 (1 row)
 
-SELECT agtype_hash_cmp('
-	[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	 {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	 {"id":5, "label":"vlabel", "properties":{}}::vertex]::path'::agtype);
- agtype_hash_cmp 
------------------
-       843330291
-(1 row)
-
 --Agtype BTree Comparison Function
 SELECT agtype_btree_cmp('1'::agtype, '1'::agtype);
  agtype_btree_cmp 
@@ -1977,30 +1968,6 @@ SELECT agtype_btree_cmp(
 SELECT agtype_btree_cmp(
 	'{"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{"prop1": 1}}::edge'::agtype,
 	'{"id":8, "start_id":4, "end_id": 5, "label":"elabel", "properties":{"prop2": 2}}::edge'::agtype);
- agtype_btree_cmp 
-------------------
-               -1
-(1 row)
-
-SELECT agtype_btree_cmp(
-	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	  {"id":3, "label":"vlabel", "properties":{}}::vertex]::path'::agtype,
-	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	  {"id":3, "label":"vlabel", "properties":{}}::vertex]::path'::agtype);
- agtype_btree_cmp 
-------------------
-                0
-(1 row)
-
-SELECT agtype_btree_cmp(
-	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	  {"id":3, "label":"vlabel", "properties":{}}::vertex]::path'::agtype,
-	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	  {"id":4, "label":"vlabel", "properties":{}}::vertex]::path'::agtype);
  agtype_btree_cmp 
 ------------------
                -1

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -1671,37 +1671,6 @@ SELECT agtype_in('{"name": "path 1", "path": [{"id": 0, "label": "vertex 0", "pr
  {"name": "path 1", "path": [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]}
 (1 row)
 
--- typecast to path
-SELECT agtype_in('[{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path');
-                                                                                                  agtype_in                                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path
-(1 row)
-
-SELECT agtype_in('{"Path" : [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path}');
-                                                                                                       agtype_in                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"Path": [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path}
-(1 row)
-
--- verify that the output can be input
-SELECT agtype_in('[{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path');
-                                                                                                  agtype_in                                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path
-(1 row)
-
-SELECT agtype_in('{"path": [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path}');
-                                                                                                       agtype_in                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"path": [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path}
-(1 row)
-
--- invalid paths should fail
-SELECT agtype_in('[{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge]::path');
-ERROR:  array is not a valid path
-SELECT agtype_in('{"Path" : [{"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path}');
-ERROR:  array is not a valid path
 -- test functions
 -- create some vertices and edges
 SELECT * FROM cypher('expr', $$CREATE (:v)$$) AS (a agtype);

--- a/regress/sql/agtype.sql
+++ b/regress/sql/agtype.sql
@@ -577,11 +577,6 @@ SELECT agtype_hash_cmp('
 	 {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
 	 {"id":5, "label":"vlabel", "properties":{}}::vertex]'::agtype);
 
-SELECT agtype_hash_cmp('
-	[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	 {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	 {"id":5, "label":"vlabel", "properties":{}}::vertex]::path'::agtype);
-
 --Agtype BTree Comparison Function
 SELECT agtype_btree_cmp('1'::agtype, '1'::agtype);
 SELECT agtype_btree_cmp('1'::agtype, '1.0'::agtype);
@@ -620,21 +615,6 @@ SELECT agtype_btree_cmp(
 	'{"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{"prop1": 1}}::edge'::agtype,
 	'{"id":8, "start_id":4, "end_id": 5, "label":"elabel", "properties":{"prop2": 2}}::edge'::agtype);
 
-SELECT agtype_btree_cmp(
-	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	  {"id":3, "label":"vlabel", "properties":{}}::vertex]::path'::agtype,
-	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	  {"id":3, "label":"vlabel", "properties":{}}::vertex]::path'::agtype);
-
-SELECT agtype_btree_cmp(
-	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	  {"id":3, "label":"vlabel", "properties":{}}::vertex]::path'::agtype,
-	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
-	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
-	  {"id":4, "label":"vlabel", "properties":{}}::vertex]::path'::agtype);
 --
 -- Cleanup
 --

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -751,16 +751,6 @@ SELECT agtype_in('{"name": "container 0", "vertices": [{"vertex_0": {"id": 0, "l
 SELECT agtype_in('{"name": "container 1", "edges": [{"id": 3, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 4, "label": "edge 1", "end_id": 0, "start_id": 1, "properties": {}}::edge]}');
 SELECT agtype_in('{"name": "path 1", "path": [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]}');
 
--- typecast to path
-SELECT agtype_in('[{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path');
-SELECT agtype_in('{"Path" : [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path}');
--- verify that the output can be input
-SELECT agtype_in('[{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path');
-SELECT agtype_in('{"path": [{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path}');
--- invalid paths should fail
-SELECT agtype_in('[{"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge]::path');
-SELECT agtype_in('{"Path" : [{"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 0, "label": "vertex 0", "properties": {}}::vertex, {"id": 2, "label": "edge 0", "end_id": 1, "start_id": 0, "properties": {}}::edge, {"id": 1, "label": "vertex 1", "properties": {}}::vertex]::path}');
-
 -- test functions
 -- create some vertices and edges
 SELECT * FROM cypher('expr', $$CREATE (:v)$$) AS (a agtype);


### PR DESCRIPTION
Always was a bad idea, need to get removed to support the independent path datatype