### PR TITLE
 Remove VLE Cacheing Mechanic

### DIFF
--- a/postgraph--0.0.1.sql
+++ b/postgraph--0.0.1.sql
@@ -527,25 +527,14 @@ CREATE AGGREGATE age_collect(agtype) (stype = internal, sfunc = age_collect_aggt
 --
 -- John's crap
 --
--- original VLE function definition
-CREATE FUNCTION age_vle(IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, OUT edges agtype)
-RETURNS SETOF agtype LANGUAGE C STABLE CALLED ON NULL INPUT PARALLEL UNSAFE AS 'MODULE_PATHNAME';
-
--- This is an overloaded function definition to allow for the VLE local context
--- caching mechanism to coexist with the previous VLE version.
-CREATE FUNCTION age_vle(IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, OUT edges agtype)
-RETURNS SETOF agtype LANGUAGE C STABLE CALLED ON NULL INPUT PARALLEL UNSAFE AS 'MODULE_PATHNAME';
--- function to build an edge for a VLE match
-
+CREATE FUNCTION age_vle(IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, IN agtype, OUT edges agtype) RETURNS SETOF agtype LANGUAGE C STABLE CALLED ON NULL INPUT PARALLEL UNSAFE AS 'MODULE_PATHNAME';
 -- TODO: remove
-CREATE FUNCTION age_build_vle_match_edge(agtype, agtype) RETURNS agtype LANGUAGE C STABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_match_vle_terminal_edge(variadic "any") RETURNS boolean LANGUAGE C STABLE CALLED ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_materialize_vle_path(agtype) RETURNS agtype LANGUAGE C STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_materialize_vle_edges(agtype) RETURNS agtype LANGUAGE C STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_match_vle_edge_to_id_qual(variadic "any") RETURNS boolean LANGUAGE C STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_match_two_vle_edges(agtype, agtype) RETURNS boolean LANGUAGE C STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_vertex_stats(agtype, agtype) RETURNS agtype LANGUAGE c STABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_delete_global_graphs(agtype) RETURNS boolean LANGUAGE c VOLATILE PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION age_build_vle_match_edge(agtype, agtype) RETURNS agtype LANGUAGE C IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION age_match_vle_terminal_edge("any", "any", agtype) RETURNS boolean LANGUAGE C STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION age_materialize_vle_path(agtype) RETURNS agtype LANGUAGE C IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION age_materialize_vle_edges(agtype) RETURNS agtype LANGUAGE C IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION age_match_vle_edge_to_id_qual(agtype, graphid, agtype) RETURNS boolean LANGUAGE C STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION age_match_two_vle_edges(agtype, agtype) RETURNS boolean LANGUAGE C IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
 
 --
 -- End

--- a/regress/expected/catalog.out
+++ b/regress/expected/catalog.out
@@ -408,8 +408,8 @@ SELECT create_graph_if_not_exists('new_g');
 SELECT * FROM postgraph.ag_graph;
  graphid | name  | namespace 
 ---------+-------+-----------
-   17239 | g     | g
-   17279 | new_g | new_g
+   17233 | g     | g
+   17273 | new_g | new_g
 (2 rows)
 
 -- dropping the graph

--- a/regress/expected/cypher_vle.out
+++ b/regress/expected/cypher_vle.out
@@ -510,15 +510,15 @@ SELECT * FROM cypher('cypher_vle', $$MATCH p=()-[*0..0]->()-[]->() RETURN p $$) 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  [{"id": 844424930131969, "label": "begin", "properties": {}}::vertex, {"id": 2251799813685249, "label": "alternate_edge", "end_id": 1407374883553281, "start_id": 844424930131969, "properties": {"name": "alternate edge", "number": 1, "packages": [2, 4, 6], "dangerous": {"type": "poisons", "level": "all"}}}::edge, {"id": 1407374883553281, "label": "middle", "properties": {}}::vertex]::path
  [{"id": 844424930131969, "label": "begin", "properties": {}}::vertex, {"id": 1125899906842628, "label": "edge", "end_id": 1407374883553281, "start_id": 844424930131969, "properties": {"name": "main edge", "number": 1, "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1407374883553281, "label": "middle", "properties": {}}::vertex]::path
- [{"id": 1407374883553281, "label": "middle", "properties": {}}::vertex, {"id": 1125899906842627, "label": "edge", "end_id": 1407374883553282, "start_id": 1407374883553281, "properties": {"name": "main edge", "number": 2, "packages": [2, 4, 6], "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1407374883553282, "label": "middle", "properties": {}}::vertex]::path
  [{"id": 1407374883553281, "label": "middle", "properties": {}}::vertex, {"id": 1970324836974593, "label": "self_loop", "end_id": 1407374883553281, "start_id": 1407374883553281, "properties": {"name": "self loop", "number": 1, "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1407374883553281, "label": "middle", "properties": {}}::vertex]::path
+ [{"id": 1407374883553281, "label": "middle", "properties": {}}::vertex, {"id": 1125899906842627, "label": "edge", "end_id": 1407374883553282, "start_id": 1407374883553281, "properties": {"name": "main edge", "number": 2, "packages": [2, 4, 6], "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1407374883553282, "label": "middle", "properties": {}}::vertex]::path
+ [{"id": 1407374883553282, "label": "middle", "properties": {}}::vertex, {"id": 2533274790395906, "label": "bypass_edge", "end_id": 844424930131969, "start_id": 1407374883553282, "properties": {"name": "bypass edge", "number": 2, "packages": [1, 3, 5, 7], "dangerous": {"type": "poisons", "level": "all"}}}::edge, {"id": 844424930131969, "label": "begin", "properties": {}}::vertex]::path
  [{"id": 1407374883553282, "label": "middle", "properties": {}}::vertex, {"id": 1125899906842626, "label": "edge", "end_id": 1407374883553283, "start_id": 1407374883553282, "properties": {"name": "main edge", "number": 3, "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1407374883553283, "label": "middle", "properties": {}}::vertex]::path
  [{"id": 1407374883553282, "label": "middle", "properties": {}}::vertex, {"id": 2251799813685250, "label": "alternate_edge", "end_id": 1407374883553283, "start_id": 1407374883553282, "properties": {"name": "alternate edge", "number": 2, "packages": [2, 4, 6], "dangerous": {"type": "poisons", "level": "all"}}}::edge, {"id": 1407374883553283, "label": "middle", "properties": {}}::vertex]::path
  [{"id": 1407374883553282, "label": "middle", "properties": {}}::vertex, {"id": 2533274790395905, "label": "bypass_edge", "end_id": 1688849860263937, "start_id": 1407374883553282, "properties": {"name": "bypass edge", "number": 1, "packages": [1, 3, 5, 7]}}::edge, {"id": 1688849860263937, "label": "end", "properties": {}}::vertex]::path
- [{"id": 1407374883553282, "label": "middle", "properties": {}}::vertex, {"id": 2533274790395906, "label": "bypass_edge", "end_id": 844424930131969, "start_id": 1407374883553282, "properties": {"name": "bypass edge", "number": 2, "packages": [1, 3, 5, 7], "dangerous": {"type": "poisons", "level": "all"}}}::edge, {"id": 844424930131969, "label": "begin", "properties": {}}::vertex]::path
- [{"id": 1407374883553283, "label": "middle", "properties": {}}::vertex, {"id": 1125899906842625, "label": "edge", "end_id": 1688849860263937, "start_id": 1407374883553283, "properties": {"name": "main edge", "number": 4, "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1688849860263937, "label": "end", "properties": {}}::vertex]::path
- [{"id": 1407374883553283, "label": "middle", "properties": {}}::vertex, {"id": 2251799813685253, "label": "alternate_edge", "end_id": 1407374883553282, "start_id": 1407374883553283, "properties": {"name": "backup edge", "number": 2, "packages": [1, 3, 5, 7]}}::edge, {"id": 1407374883553282, "label": "middle", "properties": {}}::vertex]::path
  [{"id": 1407374883553283, "label": "middle", "properties": {}}::vertex, {"id": 2251799813685251, "label": "alternate_edge", "end_id": 1688849860263937, "start_id": 1407374883553283, "properties": {"name": "alternate edge", "number": 3, "packages": [2, 4, 6], "dangerous": {"type": "poisons", "level": "all"}}}::edge, {"id": 1688849860263937, "label": "end", "properties": {}}::vertex]::path
+ [{"id": 1407374883553283, "label": "middle", "properties": {}}::vertex, {"id": 2251799813685253, "label": "alternate_edge", "end_id": 1407374883553282, "start_id": 1407374883553283, "properties": {"name": "backup edge", "number": 2, "packages": [1, 3, 5, 7]}}::edge, {"id": 1407374883553282, "label": "middle", "properties": {}}::vertex]::path
+ [{"id": 1407374883553283, "label": "middle", "properties": {}}::vertex, {"id": 1125899906842625, "label": "edge", "end_id": 1688849860263937, "start_id": 1407374883553283, "properties": {"name": "main edge", "number": 4, "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1688849860263937, "label": "end", "properties": {}}::vertex]::path
  [{"id": 1688849860263937, "label": "end", "properties": {}}::vertex, {"id": 2251799813685252, "label": "alternate_edge", "end_id": 1407374883553283, "start_id": 1688849860263937, "properties": {"name": "backup edge", "number": 1, "packages": [1, 3, 5, 7]}}::edge, {"id": 1407374883553283, "label": "middle", "properties": {}}::vertex]::path
  [{"id": 1688849860263937, "label": "end", "properties": {}}::vertex, {"id": 1970324836974594, "label": "self_loop", "end_id": 1688849860263937, "start_id": 1688849860263937, "properties": {"name": "self loop", "number": 2, "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1688849860263937, "label": "end", "properties": {}}::vertex]::path
 (13 rows)
@@ -540,6 +540,30 @@ SELECT * FROM cypher('cypher_vle', $$MATCH p=()-[]->()-[*0..0]->() RETURN p $$) 
  [{"id": 1407374883553283, "label": "middle", "properties": {}}::vertex, {"id": 1125899906842625, "label": "edge", "end_id": 1688849860263937, "start_id": 1407374883553283, "properties": {"name": "main edge", "number": 4, "dangerous": {"type": "all", "level": "all"}}}::edge, {"id": 1688849860263937, "label": "end", "properties": {}}::vertex]::path
  [{"id": 1407374883553283, "label": "middle", "properties": {}}::vertex, {"id": 2251799813685251, "label": "alternate_edge", "end_id": 1688849860263937, "start_id": 1407374883553283, "properties": {"name": "alternate edge", "number": 3, "packages": [2, 4, 6], "dangerous": {"type": "poisons", "level": "all"}}}::edge, {"id": 1688849860263937, "label": "end", "properties": {}}::vertex]::path
 (13 rows)
+
+SELECT count(*) FROM cypher('cypher_vle', $$MATCH (u)-[*]-(v) RETURN u, v$$) AS (u agtype, v agtype);
+ count  
+--------
+ 369262
+(1 row)
+
+SELECT count(*) FROM cypher('cypher_vle', $$MATCH (u)-[*0..1]-(v) RETURN u, v$$) AS (u agtype, v agtype);
+ count 
+-------
+    29
+(1 row)
+
+SELECT count(*) FROM cypher('cypher_vle', $$MATCH (u)-[*..1]-(v) RETURN u, v$$) AS (u agtype, v agtype);
+ count 
+-------
+    24
+(1 row)
+
+SELECT count(*) FROM cypher('cypher_vle', $$MATCH (u)-[*..5]-(v) RETURN u, v$$) AS (u agtype, v agtype);
+ count 
+-------
+  5450
+(1 row)
 
 --
 -- Test VLE inside of a BEGIN/COMMIT block

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -5331,75 +5331,6 @@ SELECT * FROM cypher('opt_forms', $$MATCH (u)-->()<--(v) RETURN *$$) AS (col1 ag
  {"id": 281474976710657, "label": "", "properties": {"i": 1}}::vertex | {"id": 281474976710659, "label": "", "properties": {"i": 3}}::vertex
 (2 rows)
 
--- VLE
-SELECT create_graph('VLE');
-NOTICE:  graph "VLE" has been created
- create_graph 
---------------
- 
-(1 row)
-
--- should return 0 rows
-SELECT * FROM cypher('VLE', $$MATCH (u)-[*]-(v) RETURN u, v$$) AS (u agtype, v agtype);
- u | v 
----+---
-(0 rows)
-
-SELECT * FROM cypher('VLE', $$MATCH (u)-[*0..1]-(v) RETURN u, v$$) AS (u agtype, v agtype);
- u | v 
----+---
-(0 rows)
-
-SELECT * FROM cypher('VLE', $$MATCH (u)-[*..1]-(v) RETURN u, v$$) AS (u agtype, v agtype);
- u | v 
----+---
-(0 rows)
-
-SELECT * FROM cypher('VLE', $$MATCH (u)-[*..5]-(v) RETURN u, v$$) AS (u agtype, v agtype);
- u | v 
----+---
-(0 rows)
-
--- Create a graph to test
-SELECT * FROM cypher('VLE', $$CREATE (b:begin)-[:edge {name: 'main edge', number: 1, dangerous: {type: "all", level: "all"}}]->(u1:middle)-[:edge {name: 'main edge', number: 2, dangerous: {type: "all", level: "all"}, packages: [2,4,6]}]->(u2:middle)-[:edge {name: 'main edge', number: 3, dangerous: {type: "all", level: "all"}}]->(u3:middle)-[:edge {name: 'main edge', number: 4, dangerous: {type: "all", level: "all"}}]->(e:end), (u1)-[:self_loop {name: 'self loop', number: 1, dangerous: {type: "all", level: "all"}}]->(u1), (e)-[:self_loop {name: 'self loop', number: 2, dangerous: {type: "all", level: "all"}}]->(e), (b)-[:alternate_edge {name: 'alternate edge', number: 1, packages: [2,4,6], dangerous: {type: "poisons", level: "all"}}]->(u1), (u2)-[:alternate_edge {name: 'alternate edge', number: 2, packages: [2,4,6], dangerous: {type: "poisons", level: "all"}}]->(u3), (u3)-[:alternate_edge {name: 'alternate edge', number: 3, packages: [2,4,6], dangerous: {type: "poisons", level: "all"}}]->(e), (u2)-[:bypass_edge {name: 'bypass edge', number: 1, packages: [1,3,5,7]}]->(e), (e)-[:alternate_edge {name: 'backup edge', number: 1, packages: [1,3,5,7]}]->(u3), (u3)-[:alternate_edge {name: 'backup edge', number: 2, packages: [1,3,5,7]}]->(u2), (u2)-[:bypass_edge {name: 'bypass edge', number: 2, packages: [1,3,5,7], dangerous: {type: "poisons", level: "all"}}]->(b) RETURN b, e $$) AS (b agtype, e agtype);
-                                  b                                  |                                 e                                  
----------------------------------------------------------------------+--------------------------------------------------------------------
- {"id": 844424930131969, "label": "begin", "properties": {}}::vertex | {"id": 1688849860263937, "label": "end", "properties": {}}::vertex
-(1 row)
-
--- test vertex_stats command
-SELECT * FROM cypher('VLE', $$ MATCH (u) RETURN vertex_stats(u) $$) AS (result agtype);
-                                            result                                             
------------------------------------------------------------------------------------------------
- {"id": 844424930131969, "label": "begin", "in_degree": 1, "out_degree": 2, "self_loops": 0}
- {"id": 1407374883553281, "label": "middle", "in_degree": 3, "out_degree": 2, "self_loops": 1}
- {"id": 1407374883553282, "label": "middle", "in_degree": 2, "out_degree": 4, "self_loops": 0}
- {"id": 1407374883553283, "label": "middle", "in_degree": 3, "out_degree": 3, "self_loops": 0}
- {"id": 1688849860263937, "label": "end", "in_degree": 4, "out_degree": 2, "self_loops": 1}
-(5 rows)
-
--- test indirection operator for a function
-SELECT * FROM cypher('VLE', $$ MATCH (u) WHERE vertex_stats(u).self_loops <> 0 RETURN vertex_stats(u) $$) AS (result agtype);
-                                            result                                             
------------------------------------------------------------------------------------------------
- {"id": 1407374883553281, "label": "middle", "in_degree": 3, "out_degree": 2, "self_loops": 1}
- {"id": 1688849860263937, "label": "end", "in_degree": 4, "out_degree": 2, "self_loops": 1}
-(2 rows)
-
-SELECT * FROM cypher('VLE', $$ MATCH (u) WHERE vertex_stats(u).in_degree < vertex_stats(u).out_degree RETURN vertex_stats(u) $$) AS (result agtype);
-                                            result                                             
------------------------------------------------------------------------------------------------
- {"id": 844424930131969, "label": "begin", "in_degree": 1, "out_degree": 2, "self_loops": 0}
- {"id": 1407374883553282, "label": "middle", "in_degree": 2, "out_degree": 4, "self_loops": 0}
-(2 rows)
-
-SELECT * FROM cypher('VLE', $$ MATCH (u) WHERE vertex_stats(u).out_degree < vertex_stats(u).in_degree RETURN vertex_stats(u) $$) AS (result agtype);
-                                            result                                             
------------------------------------------------------------------------------------------------
- {"id": 1407374883553281, "label": "middle", "in_degree": 3, "out_degree": 2, "self_loops": 1}
- {"id": 1688849860263937, "label": "end", "in_degree": 4, "out_degree": 2, "self_loops": 1}
-(2 rows)
-
 -- list functions relationships(), range(), keys()
 SELECT create_graph('keys');
 NOTICE:  graph "keys" has been created
@@ -5707,23 +5638,6 @@ DETAIL:  drop cascades to table chained._ag_label_vertex
 drop cascades to table chained._ag_label_edge
 drop cascades to table chained.people
 NOTICE:  graph "chained" has been dropped
- drop_graph 
-------------
- 
-(1 row)
-
-SELECT * FROM drop_graph('VLE', true);
-NOTICE:  drop cascades to 9 other objects
-DETAIL:  drop cascades to table "VLE"._ag_label_vertex
-drop cascades to table "VLE"._ag_label_edge
-drop cascades to table "VLE".begin
-drop cascades to table "VLE".edge
-drop cascades to table "VLE".middle
-drop cascades to table "VLE"."end"
-drop cascades to table "VLE".self_loop
-drop cascades to table "VLE".alternate_edge
-drop cascades to table "VLE".bypass_edge
-NOTICE:  graph "VLE" has been dropped
  drop_graph 
 ------------
  

--- a/regress/sql/cypher_vle.sql
+++ b/regress/sql/cypher_vle.sql
@@ -174,6 +174,11 @@ SELECT * FROM cypher('cypher_vle', $$MATCH p=(u)-[e*0..0]->(v) RETURN id(u), p, 
 SELECT * FROM cypher('cypher_vle', $$MATCH p=()-[*0..0]->()-[]->() RETURN p $$) AS (p agtype);
 SELECT * FROM cypher('cypher_vle', $$MATCH p=()-[]->()-[*0..0]->() RETURN p $$) AS (p agtype);
 
+SELECT count(*) FROM cypher('cypher_vle', $$MATCH (u)-[*]-(v) RETURN u, v$$) AS (u agtype, v agtype);
+SELECT count(*) FROM cypher('cypher_vle', $$MATCH (u)-[*0..1]-(v) RETURN u, v$$) AS (u agtype, v agtype);
+SELECT count(*) FROM cypher('cypher_vle', $$MATCH (u)-[*..1]-(v) RETURN u, v$$) AS (u agtype, v agtype);
+SELECT count(*) FROM cypher('cypher_vle', $$MATCH (u)-[*..5]-(v) RETURN u, v$$) AS (u agtype, v agtype);
+
 --
 -- Test VLE inside of a BEGIN/COMMIT block
 --

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -2166,26 +2166,6 @@ SELECT * FROM cypher('opt_forms', $$MATCH (u)-->()<--(v) RETURN u.i, v.i$$) AS (
 SELECT * FROM cypher('opt_forms', $$MATCH (u) CREATE (u)-[:edge]->() RETURN *$$) AS (results agtype);
 SELECT * FROM cypher('opt_forms', $$MATCH (u)-->()<--(v) RETURN *$$) AS (col1 agtype, col2 agtype);
 
--- VLE
-SELECT create_graph('VLE');
--- should return 0 rows
-SELECT * FROM cypher('VLE', $$MATCH (u)-[*]-(v) RETURN u, v$$) AS (u agtype, v agtype);
-SELECT * FROM cypher('VLE', $$MATCH (u)-[*0..1]-(v) RETURN u, v$$) AS (u agtype, v agtype);
-SELECT * FROM cypher('VLE', $$MATCH (u)-[*..1]-(v) RETURN u, v$$) AS (u agtype, v agtype);
-SELECT * FROM cypher('VLE', $$MATCH (u)-[*..5]-(v) RETURN u, v$$) AS (u agtype, v agtype);
-
--- Create a graph to test
-SELECT * FROM cypher('VLE', $$CREATE (b:begin)-[:edge {name: 'main edge', number: 1, dangerous: {type: "all", level: "all"}}]->(u1:middle)-[:edge {name: 'main edge', number: 2, dangerous: {type: "all", level: "all"}, packages: [2,4,6]}]->(u2:middle)-[:edge {name: 'main edge', number: 3, dangerous: {type: "all", level: "all"}}]->(u3:middle)-[:edge {name: 'main edge', number: 4, dangerous: {type: "all", level: "all"}}]->(e:end), (u1)-[:self_loop {name: 'self loop', number: 1, dangerous: {type: "all", level: "all"}}]->(u1), (e)-[:self_loop {name: 'self loop', number: 2, dangerous: {type: "all", level: "all"}}]->(e), (b)-[:alternate_edge {name: 'alternate edge', number: 1, packages: [2,4,6], dangerous: {type: "poisons", level: "all"}}]->(u1), (u2)-[:alternate_edge {name: 'alternate edge', number: 2, packages: [2,4,6], dangerous: {type: "poisons", level: "all"}}]->(u3), (u3)-[:alternate_edge {name: 'alternate edge', number: 3, packages: [2,4,6], dangerous: {type: "poisons", level: "all"}}]->(e), (u2)-[:bypass_edge {name: 'bypass edge', number: 1, packages: [1,3,5,7]}]->(e), (e)-[:alternate_edge {name: 'backup edge', number: 1, packages: [1,3,5,7]}]->(u3), (u3)-[:alternate_edge {name: 'backup edge', number: 2, packages: [1,3,5,7]}]->(u2), (u2)-[:bypass_edge {name: 'bypass edge', number: 2, packages: [1,3,5,7], dangerous: {type: "poisons", level: "all"}}]->(b) RETURN b, e $$) AS (b agtype, e agtype);
-
--- test vertex_stats command
-SELECT * FROM cypher('VLE', $$ MATCH (u) RETURN vertex_stats(u) $$) AS (result agtype);
-
--- test indirection operator for a function
-SELECT * FROM cypher('VLE', $$ MATCH (u) WHERE vertex_stats(u).self_loops <> 0 RETURN vertex_stats(u) $$) AS (result agtype);
-SELECT * FROM cypher('VLE', $$ MATCH (u) WHERE vertex_stats(u).in_degree < vertex_stats(u).out_degree RETURN vertex_stats(u) $$) AS (result agtype);
-SELECT * FROM cypher('VLE', $$ MATCH (u) WHERE vertex_stats(u).out_degree < vertex_stats(u).in_degree RETURN vertex_stats(u) $$) AS (result agtype);
-
-
 -- list functions relationships(), range(), keys()
 SELECT create_graph('keys');
 -- keys()
@@ -2265,7 +2245,6 @@ SELECT * from cypher('list', $$RETURN labels("string")$$) as (Labels agtype);
 -- Cleanup
 --
 SELECT * FROM drop_graph('chained', true);
-SELECT * FROM drop_graph('VLE', true);
 SELECT * FROM drop_graph('case_statement', true);
 SELECT * FROM drop_graph('opt_forms', true);
 SELECT * FROM drop_graph('type_coercion', true);

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -32,7 +32,7 @@
 #include "utils/age_graphid_ds.h"
 #include "nodes/cypher_nodes.h"
 
-/* defines */
+// defines 
 #define GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc) \
             (graphid *) (&vpc->graphid_array_data)
 #define EDGE_STATE_HTAB_NAME "Edge state "
@@ -41,53 +41,44 @@
 #define EXISTS_HTAB_NAME_INITIAL_SIZE 1000
 #define MAXIMUM_NUMBER_OF_CACHED_LOCAL_CONTEXTS 5
 
-/* edge state entry for the edge_state_hashtable */
+// edge state entry for the edge_state_hashtable 
 typedef struct edge_state_entry
 {
-    graphid edge_id;               /* edge id, it is also the hash key */
-    bool used_in_path;             /* like visited but more descriptive */
-    bool has_been_matched;         /* have we checked for a  match */
-    bool matched;                  /* is it a match */
+    graphid edge_id;               // edge id, it is also the hash key 
+    bool used_in_path;             // like visited but more descriptive 
+    bool has_been_matched;         // have we checked for a  match 
+    bool matched;                  // is it a match 
 } edge_state_entry;
 
-/*
- * VLE_path_function is an enum for the path function to use. This currently can
- * be one of two possibilities - where the target vertex is provided and where
- * it isn't.
- */
+// path function to use.
 typedef enum
-{                                  /* Given a path (u)-[e]-(v)                */
-    VLE_FUNCTION_PATHS_FROM,       /* Paths from a (u) without a provided (v) */
-    VLE_FUNCTION_PATHS_TO,         /* Paths to a (v) without a provided (u)   */
-    VLE_FUNCTION_PATHS_BETWEEN,    /* Paths between a (u) and a provided (v)  */
-    VLE_FUNCTION_PATHS_ALL,        /* All paths without a provided (u) or (v) */
+{                                  // Given a path (u)-[e]-(v)                
+    VLE_FUNCTION_PATHS_FROM,       // Paths from a (u) without a provided (v) 
+    VLE_FUNCTION_PATHS_BETWEEN,    // Paths between a (u) and a provided (v)  
     VLE_FUNCTION_NONE
 } VLE_path_function;
 
-/* VLE local context per each unique age_vle function activation */
+// VLE local context per each unique age_vle function activation 
 typedef struct path_finding_context
 {
-    char *graph_name;              /* name of the graph */
-    Oid graph_oid;                 /* graph oid for searching */
-    graph_context *ggctx;   /* global graph context pointer */
-    graphid vsid;                  /* starting vertex id */
-    graphid veid;                  /* ending vertex id */
-    char *edge_label_name;         /* edge label name for match */
-    agtype *edge_property_constraint; /* edge property constraint as agtype */
-    int64 lidx;                    /* lower (start) bound index */
-    int64 uidx;                    /* upper (end) bound index */
-    bool uidx_infinite;            /* flag if the upper bound is omitted */
-    cypher_rel_dir edge_direction; /* the direction of the edge */
-    HTAB *edge_state_hashtable;    /* local state hashtable for our edges */
-    ListGraphId *dfs_vertex_stack; /* dfs stack for vertices */
-    ListGraphId *dfs_edge_stack;   /* dfs stack for edges */
-    ListGraphId *dfs_path_stack;   /* dfs stack containing the path */
-    VLE_path_function path_function; /* which path function to use */
-    GraphIdNode *next_vertex;      /* for VLE_FUNCTION_PATHS_TO */
-    int64 vle_grammar_node_id;     /* the unique VLE grammar assigned node id */
-    bool use_cache;                /* are we using path_finding_context cache */
-    struct path_finding_context *next;  /* the next chained path_finding_context */
-    bool is_dirty;                 /* is this VLE context reusable */
+    char *graph_name;              // name of the graph 
+    Oid graph_oid;                 // graph oid for searching 
+    graph_context *ggctx;   // global graph context pointer 
+    graphid vsid;                  // starting vertex id 
+    graphid veid;                  // ending vertex id 
+    char *edge_label_name;         // edge label name for match 
+    agtype *edge_property_constraint; // edge property constraint as agtype 
+    int64 lidx;                    // lower (start) bound index 
+    int64 uidx;                    // upper (end) bound index 
+    bool uidx_infinite;            // flag if the upper bound is omitted 
+    cypher_rel_dir edge_direction; // the direction of the edge 
+    HTAB *edge_state_hashtable;    // local state hashtable for our edges 
+    ListGraphId *dfs_vertex_stack; // dfs stack for vertices 
+    ListGraphId *dfs_edge_stack;   // dfs stack for edges 
+    ListGraphId *dfs_path_stack;   // dfs stack containing the path 
+    VLE_path_function path_function; // which path function to use 
+    GraphIdNode *next_vertex;      // for VLE_FUNCTION_PATHS_TO 
+    struct path_finding_context *next;  // the next chained path_finding_context 
 } path_finding_context;
 
 /*
@@ -98,7 +89,7 @@ typedef struct path_finding_context
  */
 typedef struct path_container
 {
-    char vl_len_[4]; /* Do not touch this field! */
+    char vl_len_[4]; // Do not touch this field! 
     uint32 header;
     uint32 graph_oid;
     int64 graphid_array_size;
@@ -106,219 +97,54 @@ typedef struct path_container
     graphid graphid_array_data;
 } path_container;
 
-/* declarations */
-
-/* global variable to hold the per process global cached VLE_local contexts */
-static path_finding_context *global_vle_local_contexts = NULL;
-
-/* agtype functions */
-static bool is_an_edge_match(path_finding_context *vlelctx, edge_entry *ee);
-/* VLE local context functions */
-static path_finding_context *build_local_vle_context(FunctionCallInfo fcinfo,
-                                                  FuncCallContext *funcctx);
-static void create_VLE_local_state_hashtable(path_finding_context *vlelctx);
-static void free_path_finding_context(path_finding_context *vlelctx);
-/* VLE graph traversal functions */
-static edge_state_entry *get_edge_state(path_finding_context *vlelctx,
-                                        graphid edge_id);
-/* graphid data structures */
-static void load_initial_dfs_stacks(path_finding_context *vlelctx);
-static bool dfs_find_a_path_between(path_finding_context *vlelctx);
-static bool dfs_find_a_path_from(path_finding_context *vlelctx);
-static bool do_vsid_and_veid_exist(path_finding_context *vlelctx);
-static void add_valid_vertex_edges(path_finding_context *vlelctx,
-                                   graphid vertex_id);
-static graphid get_next_vertex(path_finding_context *vlelctx, edge_entry *ee);
-static bool is_edge_in_path(path_finding_context *vlelctx, graphid edge_id);
-/* VLE path and edge building functions */
+// agtype functions 
+static bool is_an_edge_match(path_finding_context *path_ctx, edge_entry *ee);
+// VLE local context functions 
+static path_finding_context *build_vle_context(FunctionCallInfo fcinfo, FuncCallContext *funcctx);
+static void create_VLE_local_state_hashtable(path_finding_context *path_ctx);
+// VLE graph traversal functions 
+static edge_state_entry *get_edge_state(path_finding_context *path_ctx, graphid edge_id);
+// graphid data structures 
+static void load_initial_dfs_stacks(path_finding_context *path_ctx);
+static bool dfs_find_a_path_between(path_finding_context *path_ctx);
+static bool dfs_find_a_path_from(path_finding_context *path_ctx);
+static bool do_vsid_and_veid_exist(path_finding_context *path_ctx);
+static void add_valid_vertex_edges(path_finding_context *path_ctx, graphid vertex_id);
+static graphid get_next_vertex(path_finding_context *path_ctx, edge_entry *ee);
+static bool is_edge_in_path(path_finding_context *path_ctx, graphid edge_id);
+// VLE path and edge building functions 
 static path_container *create_path_container(int64 path_size);
-static path_container *build_path_container(path_finding_context *vlelctx);
-static path_container *build_VLE_zero_container(path_finding_context *vlelctx);
+static path_container *build_path_container(path_finding_context *path_ctx);
 static agtype_value *build_path(path_container *vpc);
 static agtype_value *build_edge_list(path_container *vpc);
-/* path_finding_context cache management */
-static path_finding_context *get_cached_path_finding_context(int64 vle_node_id);
-static void cache_path_finding_context(path_finding_context *vlelctx);
 
-/* definitions */
 
-/*
- * Helper function to retrieve a cached VLE local context. It will also purge
- * off any contexts beyond the maximum defined number of cached contexts. It
- * will promote (a very basic LRU) the recently fetched context to the head of
- * the list. If a context doesn't exist or is dirty, it will purge it off and
- * return NULL.
- */
-static path_finding_context *get_cached_path_finding_context(int64 vle_grammar_node_id)
-{
-    path_finding_context *vlelctx = global_vle_local_contexts;
-    path_finding_context *prev = NULL;
-    path_finding_context *next = NULL;
-    int cache_size = 0;
-
-    /* while we have contexts to check */
-    while (vlelctx != NULL)
-    {
-        /* purge any contexts past the maximum cache size */
-        if (cache_size >= MAXIMUM_NUMBER_OF_CACHED_LOCAL_CONTEXTS)
-        {
-            /* set the next pointer to the context that follows */
-            next = vlelctx->next;
-
-            /*
-             * Clear (unlink) the previous context's next pointer, if needed.
-             * Also clear prev as we are at the end of avaiable cached contexts
-             * and just purging them off. Remember, this forms a loop that will
-             * exit the while after purging.
-             */
-            if (prev != NULL)
-            {
-                prev->next = NULL;
-                prev = NULL;
-            }
-
-            /* free the context */
-            free_path_finding_context(vlelctx);
-
-            /* set to the next one */
-            vlelctx = next;
-
-            /* if there is another context beyond the max, we will re-enter */
-            continue;
-        }
-
-        /* if this context belongs to this grammar node */
-        if (vlelctx->vle_grammar_node_id == vle_grammar_node_id)
-        {
-            /* and isn't dirty */
-            if (vlelctx->is_dirty == false)
-            {
-                graph_context *ggctx = NULL;
-
-                /*
-                 * Get the GRAPH global context associated with this local VLE
-                 * context. We need to verify it still exists and that the
-                 * pointer is valid.
-                 */
-                ggctx = find_graph_context(vlelctx->graph_oid);
-
-                /*
-                 * If ggctx == NULL, vlelctx is bad and vlelctx needs to be
-                 * removed.
-                 * If ggctx == vlelctx->ggctx, then vlelctx is good.
-                 * If ggctx != vlelctx->ggctx, then vlelctx needs to be updated.
-                 * In the end, vlelctx->ggctx will be set to ggctx.
-                 */
-
-                /*
-                 * If the returned ggctx isn't valid (there was some update to
-                 * the underlying graph), then set it to NULL. This will force a
-                 * rebuild of it.
-                 */
-                if (ggctx != NULL && is_ggctx_invalid(ggctx))
-                {
-                    ggctx = NULL;
-                }
-
-                vlelctx->ggctx = ggctx;
-
-                /*
-                 * If the context is good and isn't at the head of the cache,
-                 * promote it to the head.
-                 */
-                if (ggctx != NULL && vlelctx != global_vle_local_contexts)
-                {
-                    /* adjust the links to cut out the node */
-                    prev->next = vlelctx->next;
-                    /* point the context to the old head of the list */
-                    vlelctx->next = global_vle_local_contexts;
-                    /* point the head to this context */
-                    global_vle_local_contexts = vlelctx;
-                }
-
-                /* if we have a good one, return it. */
-                if (ggctx != NULL)
-                {
-                    return vlelctx;
-                }
-            }
-
-            /* otherwise, clean and remove it, and return NULL */
-
-            /* set the top if necessary and unlink it */
-            if (prev == NULL)
-            {
-                global_vle_local_contexts = vlelctx->next;
-            }
-            else
-            {
-                prev->next = vlelctx->next;
-            }
-
-            /* now free it and return NULL */
-            free_path_finding_context(vlelctx);
-            return NULL;
-        }
-        /* save the previous context */
-        prev = vlelctx;
-        /* get the next context */
-        vlelctx = vlelctx->next;
-        /* keep track of cache size */
-        cache_size++;
-    }
-    return vlelctx;
-}
-
-static void cache_path_finding_context(path_finding_context *vlelctx)
-{
-    /* if the context passed is null, just return */
-    if (vlelctx == NULL)
-    {
-        return;
-    }
-
-    /* if the global link is null, just assign it the local context */
-    if (global_vle_local_contexts == NULL)
-    {
-        global_vle_local_contexts = vlelctx;
-        return;
-    }
-
-    /* if there is a global link, add the local context to the top */
-    vlelctx->next = global_vle_local_contexts;
-    global_vle_local_contexts = vlelctx;
-}
-
-/* helper function to create the local VLE edge state hashtable. */
-static void create_VLE_local_state_hashtable(path_finding_context *vlelctx)
-{
+// helper function to create the local VLE edge state hashtable. 
+static void create_VLE_local_state_hashtable(path_finding_context *path_ctx) {
     HASHCTL edge_state_ctl;
     char *graph_name = NULL;
     char *eshn = NULL;
     int glen;
     int elen;
 
-    /* get the graph name and length */
-    graph_name = vlelctx->graph_name;
+    // get the graph name and length 
+    graph_name = path_ctx->graph_name;
     glen = strlen(graph_name);
-    /* get the edge state htab name length */
+    // get the edge state htab name length 
     elen = strlen(EDGE_STATE_HTAB_NAME);
-    /* allocate the space and build the name */
+    // allocate the space and build the name 
     eshn = palloc0(elen + glen + 1);
-    /* copy in the name */
+    // copy in the name 
     strcpy(eshn, EDGE_STATE_HTAB_NAME);
-    /* add in the graph name */
+    // add in the graph name 
     eshn = strncat(eshn, graph_name, glen);
 
-    /* initialize the edge state hashtable */
+    // initialize the edge state hashtable 
     MemSet(&edge_state_ctl, 0, sizeof(edge_state_ctl));
     edge_state_ctl.keysize = sizeof(int64);
     edge_state_ctl.entrysize = sizeof(edge_state_entry);
     edge_state_ctl.hash = tag_hash;
-    vlelctx->edge_state_hashtable = hash_create(eshn,
-                                                EDGE_STATE_HTAB_INITIAL_SIZE,
-                                                &edge_state_ctl,
-                                                HASH_ELEM | HASH_FUNCTION);
+    path_ctx->edge_state_hashtable = hash_create(eshn, EDGE_STATE_HTAB_INITIAL_SIZE, &edge_state_ctl, HASH_ELEM | HASH_FUNCTION);
     pfree(eshn);
 }
 
@@ -326,7 +152,7 @@ static void create_VLE_local_state_hashtable(path_finding_context *vlelctx)
  * Helper function to compare the edge constraint (properties we are looking
  * for in a matching edge) against an edge entry's property.
  */
-static bool is_an_edge_match(path_finding_context *vlelctx, edge_entry *ee)
+static bool is_an_edge_match(path_finding_context *path_ctx, edge_entry *ee)
 {
     agtype *edge_property = NULL;
     agtype_container *agtc_edge_property = NULL;
@@ -337,27 +163,25 @@ static bool is_an_edge_match(path_finding_context *vlelctx, edge_entry *ee)
     int num_edge_property_constraints = 0;
     int num_edge_properties = 0;
 
-    /* get the number of conditions from the prototype edge */
-    num_edge_property_constraints = AGT_ROOT_COUNT(vlelctx->edge_property_constraint);
+    // get the number of conditions from the prototype edge 
+    num_edge_property_constraints = AGT_ROOT_COUNT(path_ctx->edge_property_constraint);
 
     /*
      * We only care about verifying that we have all of the property conditions.
      * We don't care about extra unmatched properties. If there aren't any edge
      * constraints, then the edge passes by default.
      */
-    if (vlelctx->edge_label_name == NULL && num_edge_property_constraints == 0)
-    {
+    if (path_ctx->edge_label_name == NULL && num_edge_property_constraints == 0)
         return true;
-    }
 
-    /* get the edge label name from the oid */
+    // get the edge label name from the oid 
     edge_label_name = get_rel_name(get_edge_entry_label_table_oid(ee));
-    /* get our edge's properties */
+    // get our edge's properties 
     edge_property = DATUM_GET_AGTYPE_P(get_edge_entry_properties(ee));
-    /* get the containers */
-    agtc_edge_property_constraint = &vlelctx->edge_property_constraint->root;
+    // get the containers 
+    agtc_edge_property_constraint = &path_ctx->edge_property_constraint->root;
     agtc_edge_property = &edge_property->root;
-    /* get the number of properties in the edge to be matched */
+    // get the number of properties in the edge to be matched 
     num_edge_properties = AGTYPE_CONTAINER_SIZE(agtc_edge_property);
 
     /*
@@ -366,452 +190,166 @@ static bool is_an_edge_match(path_finding_context *vlelctx, edge_entry *ee)
      * can't possibly match.
      */
     if (num_edge_property_constraints > num_edge_properties)
-    {
         return false;
-    }
 
     /*
      * Check for a label constraint. If the label name is NULL, there isn't one.
      */
-    if (vlelctx->edge_label_name != NULL &&
-        strcmp(vlelctx->edge_label_name, edge_label_name) != 0)
-    {
+    if (path_ctx->edge_label_name != NULL && strcmp(path_ctx->edge_label_name, edge_label_name) != 0)
         return false;
-    }
 
-    /* get the iterators */
+    // get the iterators 
     constraint_it = agtype_iterator_init(agtc_edge_property_constraint);
     property_it = agtype_iterator_init(agtc_edge_property);
 
-    /* return the value of deep contains */
+    // return the value of deep contains 
     return agtype_deep_contains(&property_it, &constraint_it);
 }
 
-/*
- * Helper function to free up the memory used by the path_finding_context.
- *
- * Currently, the only structures that needs to be freed are the edge state
- * hashtable and the dfs stacks (vertex, edge, and path). The hashtable is easy
- * because hash_create packages everything into its own memory context. So, you
- * only need to do a destroy.
- */
-static void free_path_finding_context(path_finding_context *vlelctx)
+// helper function to check if our start and end vertices exist 
+static bool do_vsid_and_veid_exist(path_finding_context *path_ctx)
 {
-    /* if the VLE context is NULL, do nothing */
-    if (vlelctx == NULL)
-    {
-        return;
-    }
+    // if we are only using the starting vertex 
+    if (path_ctx->path_function == VLE_FUNCTION_PATHS_FROM)
+        return (get_vertex_entry(path_ctx->ggctx, path_ctx->vsid) != NULL);
 
-    /* free the stored graph name */
-    if (vlelctx->graph_name != NULL)
-    {
-        pfree(vlelctx->graph_name);
-        vlelctx->graph_name = NULL;
-    }
-
-    /* free the stored edge label name */
-    if (vlelctx->edge_label_name != NULL)
-    {
-        pfree(vlelctx->edge_label_name);
-        vlelctx->edge_label_name = NULL;
-    }
-
-    /* we need to free our state hashtable */
-    hash_destroy(vlelctx->edge_state_hashtable);
-    vlelctx->edge_state_hashtable = NULL;
-
-    /*
-     * We need to free the contents of our stacks if the context is not dirty.
-     * These stacks are created in a more volatile memory context. If the
-     * process was interupted, they will be garbage collected by PG. The only
-     * time we will ever clean them here is if the cache isn't being used.
-     */
-    if (vlelctx->is_dirty == false)
-    {
-        free_graphid_stack(vlelctx->dfs_vertex_stack);
-        free_graphid_stack(vlelctx->dfs_edge_stack);
-        free_graphid_stack(vlelctx->dfs_path_stack);
-    }
-
-    /* free the containers */
-    pfree(vlelctx->dfs_vertex_stack);
-    pfree(vlelctx->dfs_edge_stack);
-    pfree(vlelctx->dfs_path_stack);
-    vlelctx->dfs_vertex_stack = NULL;
-    vlelctx->dfs_edge_stack = NULL;
-    vlelctx->dfs_path_stack = NULL;
-
-    /* and finally the context itself */
-    pfree(vlelctx);
-    vlelctx = NULL;
+    // if we are using both start and end 
+    return ((get_vertex_entry(path_ctx->ggctx, path_ctx->vsid) != NULL) && (get_vertex_entry(path_ctx->ggctx, path_ctx->veid) != NULL));
 }
 
-/* helper function to check if our start and end vertices exist */
-static bool do_vsid_and_veid_exist(path_finding_context *vlelctx)
+// load the initial edges into the dfs_edge_stack 
+static void load_initial_dfs_stacks(path_finding_context *path_ctx)
 {
-    /* if we are only using the starting vertex */
-    if (vlelctx->path_function == VLE_FUNCTION_PATHS_FROM ||
-        vlelctx->path_function == VLE_FUNCTION_PATHS_ALL)
-    {
-        return (get_vertex_entry(vlelctx->ggctx, vlelctx->vsid) != NULL);
-    }
-
-    /* if we are only using the ending vertex */
-    if (vlelctx->path_function == VLE_FUNCTION_PATHS_TO)
-    {
-        return (get_vertex_entry(vlelctx->ggctx, vlelctx->veid) != NULL);
-    }
-
-    /* if we are using both start and end */
-    return ((get_vertex_entry(vlelctx->ggctx, vlelctx->vsid) != NULL) &&
-            (get_vertex_entry(vlelctx->ggctx, vlelctx->veid) != NULL));
-}
-
-/* load the initial edges into the dfs_edge_stack */
-static void load_initial_dfs_stacks(path_finding_context *vlelctx)
-{
-    /*
-     * If either the vsid or veid don't exist - don't load anything because
-     * there won't be anything to find.
-     */
-    if (!do_vsid_and_veid_exist(vlelctx))
-    {
+    if (!do_vsid_and_veid_exist(path_ctx))
         return;
-    }
 
-    /* add in the edges for the start vertex */
-    add_valid_vertex_edges(vlelctx, vlelctx->vsid);
+    // add in the edges for the start vertex 
+    add_valid_vertex_edges(path_ctx, path_ctx->vsid);
 }
 
 /*
- * Helper function to build the local VLE context. This is also the point
- * where, if necessary, the global GRAPH contexts are created and freed.
+ * build the local VLE context.
  */
-static path_finding_context *build_local_vle_context(FunctionCallInfo fcinfo,
-                                                  FuncCallContext *funcctx)
-{
-    MemoryContext oldctx = NULL;
-    graph_context *ggctx = NULL;
-    path_finding_context *vlelctx = NULL;
-    agtype_value *agtv_temp = NULL;
-    agtype_value *agtv_object = NULL;
-    char *graph_name = NULL;
-    Oid graph_oid = InvalidOid;
-    int64 vle_grammar_node_id = 0;
-    bool use_cache = false;
+static path_finding_context *build_vle_context(FunctionCallInfo fcinfo, FuncCallContext *funcctx) {
+    MemoryContext oldctx = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
-    /*
-     * Get the VLE grammar node id, if it exists. Remember, we overload the
-     * age_vle function, for now, for backwards compatability
-     */
-    if (PG_NARGS() == 8)
-    {
-        /* get the VLE grammar node id */
-        agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(7),
-                                     AGTV_INTEGER, true);
-        vle_grammar_node_id = agtv_temp->val.int_value;
-
-        /* we are using the VLE local context cache, so set it */
-        use_cache = true;
-    }
-
-    /* fetch the path_finding_context if it is cached */
-    vlelctx = get_cached_path_finding_context(vle_grammar_node_id);
-
-    /* if we are caching path_finding_contexts and this grammar node is cached */
-    if (use_cache && vlelctx != NULL)
-    {
-        /*
-         * No context change is needed here as the cache entry is in the proper
-         * context. Additionally, all of the modifications are either pointers
-         * to objects already in the proper context or primative types that will
-         * be stored in that context since the memory is allocated there.
-         */
-
-        /* get and update the start vertex id */
-        if (PG_ARGISNULL(1) || is_agtype_null(AG_GET_ARG_AGTYPE_P(1)))
-        {
-            vlelctx->vsid = get_graphid(vlelctx->next_vertex);
-            /* increment to the next vertex */
-            vlelctx->next_vertex = next_GraphIdNode(vlelctx->next_vertex);
-        }
-        else
-        {
-            agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(1),
-                                         AGTV_VERTEX, false);
-            if (agtv_temp != NULL && agtv_temp->type == AGTV_VERTEX)
-            {
-                agtv_temp = GET_AGTYPE_VALUE_OBJECT_VALUE(agtv_temp, "id");
-            }
-            else if (agtv_temp == NULL || agtv_temp->type != AGTV_INTEGER)
-            {
-                ereport(ERROR,
-                        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                         errmsg("start vertex argument must be a vertex or the integer id")));
-            }
-            vlelctx->vsid = agtv_temp->val.int_value;
-        }
-
-        /* get and update the end vertex id */
-        if (PG_ARGISNULL(2) || is_agtype_null(AG_GET_ARG_AGTYPE_P(2)))
-        {
-            vlelctx->veid = 0;
-        }
-        else
-        {
-            agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(2),
-                                         AGTV_VERTEX, false);
-            if (agtv_temp != NULL && agtv_temp->type == AGTV_VERTEX)
-            {
-                agtv_temp = GET_AGTYPE_VALUE_OBJECT_VALUE(agtv_temp, "id");
-            }
-            else if (agtv_temp == NULL || agtv_temp->type != AGTV_INTEGER)
-            {
-                ereport(ERROR,
-                        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                         errmsg("end vertex argument must be a vertex or the integer id")));
-            }
-            vlelctx->veid = agtv_temp->val.int_value;
-        }
-        vlelctx->is_dirty = true;
-
-        /* we need the SRF context to add in the edges to the stacks */
-        oldctx = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
-
-        /* load the initial edges into the dfs stacks */
-        load_initial_dfs_stacks(vlelctx);
-
-        /* switch back to the original context */
-        MemoryContextSwitchTo(oldctx);
-
-        /* return the context */
-        return vlelctx;
-    }
-
-    /* we are not using a cached path_finding_context, so create a new one */
-
-    /*
-     * If we are going to cache this context, we need to use TopMemoryContext
-     * to save the contents of the context. Otherwise, we just use a regular
-     * context for SRFs
-     */
-    if (use_cache == true)
-    {
-        oldctx = MemoryContextSwitchTo(TopMemoryContext);
-    }
-    else
-    {
-        oldctx = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
-    }
-
-    /* get the graph name - this is a required argument */
-    agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(0),
-                                 AGTV_STRING, true);
-    graph_name = pnstrdup(agtv_temp->val.string.val,
-                          agtv_temp->val.string.len);
-    /* get the graph oid */
-    graph_oid = get_graph_oid(graph_name);
+    // get the graph name - this is a required argument 
+    agtype_value *agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(0), AGTV_STRING, true);
+    char *graph_name = pnstrdup(agtv_temp->val.string.val, agtv_temp->val.string.len);
+    Oid graph_oid = get_graph_oid(graph_name);
 
     /*
      * Create or retrieve the GRAPH global context for this graph. This function
      * will also purge off invalidated contexts.
     */
-    ggctx = manage_graph_contexts(graph_name, graph_oid);
+    graph_context *ggctx = manage_graph_contexts(graph_name, graph_oid);
 
-    /* allocate and initialize local VLE context */
-    vlelctx = palloc0(sizeof(path_finding_context));
+    // allocate and initialize local VLE context 
+    path_finding_context *path_ctx = palloc0(sizeof(path_finding_context));
 
-    /* store the cache usage */
-    vlelctx->use_cache = use_cache;
+    // set the graph name and id 
+    path_ctx->graph_name = graph_name;
+    path_ctx->graph_oid = graph_oid;
 
-    /* set the VLE grammar node id */
-    vlelctx->vle_grammar_node_id = vle_grammar_node_id;
+    // set the global context referenced by this local VLE context 
+    path_ctx->ggctx = ggctx;
 
-    /* set the graph name and id */
-    vlelctx->graph_name = graph_name;
-    vlelctx->graph_oid = graph_oid;
+    // initialize the next vertex, in this case the first 
+    path_ctx->next_vertex = peek_stack_head(get_graph_vertices(ggctx));
+    Assert(path_ctx->next_vertex);
+    
+    // start id
+    agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(1), AGTV_VERTEX, false);
 
-    /* set the global context referenced by this local VLE context */
-    vlelctx->ggctx = ggctx;
+    if (agtv_temp->type == AGTV_VERTEX)
+        agtv_temp = GET_AGTYPE_VALUE_OBJECT_VALUE(agtv_temp, "id");
+    else if (agtv_temp == NULL || agtv_temp->type != AGTV_INTEGER)
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("invalid start id")));
 
-    /* initialize the path function */
-    vlelctx->path_function = VLE_FUNCTION_PATHS_BETWEEN;
+    path_ctx->vsid = agtv_temp->val.int_value;
 
-    /* initialize the next vertex, in this case the first */
-    vlelctx->next_vertex = peek_stack_head(get_graph_vertices(ggctx));
-
-    /* if there isn't one, the graph is empty */
-    if (vlelctx->next_vertex == NULL)
-    {
-        elog(ERROR, "age_vle: empty graph");
-    }
-    /*
-     * Get the start vertex id - this is an optional parameter and determines
-     * which path function is used. If a start vertex isn't provided, we
-     * retrieve them incrementally from the vertices list.
-     */
-    if (PG_ARGISNULL(1) || is_agtype_null(AG_GET_ARG_AGTYPE_P(1)))
-    {
-        /* set _TO */
-        vlelctx->path_function = VLE_FUNCTION_PATHS_TO;
-
-        /* get the start vertex */
-        vlelctx->vsid = get_graphid(vlelctx->next_vertex);
-        /* increment to the next vertex */
-        vlelctx->next_vertex = next_GraphIdNode(vlelctx->next_vertex);
-    }
-    else
-    {
-        agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(1),
-                                     AGTV_VERTEX, false);
-        if (agtv_temp != NULL && agtv_temp->type == AGTV_VERTEX)
-        {
+    // end id - determines which path function is used.
+    if (PG_ARGISNULL(2) || is_agtype_null(AG_GET_ARG_AGTYPE_P(2))) {
+            path_ctx->path_function = VLE_FUNCTION_PATHS_FROM;
+        path_ctx->veid = 0;
+    } else {
+        agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(2), AGTV_VERTEX, false);
+        if (agtv_temp->type == AGTV_VERTEX)
             agtv_temp = GET_AGTYPE_VALUE_OBJECT_VALUE(agtv_temp, "id");
-        }
-        else if (agtv_temp == NULL || agtv_temp->type != AGTV_INTEGER)
-        {
-            ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("start vertex argument must be a vertex or the integer id")));
-        }
-        vlelctx->vsid = agtv_temp->val.int_value;
+        else if (agtv_temp->type != AGTV_INTEGER)
+            ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("invalid end id")));
+        
+        path_ctx->path_function = VLE_FUNCTION_PATHS_BETWEEN;
+        path_ctx->veid = agtv_temp->val.int_value;
     }
 
-    /*
-     * Get the end vertex id - this is an optional parameter and determines
-     * which path function is used.
-     */
-    if (PG_ARGISNULL(2) || is_agtype_null(AG_GET_ARG_AGTYPE_P(2)))
-    {
-        if (vlelctx->path_function == VLE_FUNCTION_PATHS_TO)
-        {
-            vlelctx->path_function = VLE_FUNCTION_PATHS_ALL;
-        }
-        else
-        {
-            vlelctx->path_function = VLE_FUNCTION_PATHS_FROM;
-        }
-        vlelctx->veid = 0;
-    }
-    else
-    {
-        agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(2),
-                                     AGTV_VERTEX, false);
-        if (agtv_temp != NULL && agtv_temp->type == AGTV_VERTEX)
-        {
-            agtv_temp = GET_AGTYPE_VALUE_OBJECT_VALUE(agtv_temp, "id");
-        }
-        else if (agtv_temp == NULL || agtv_temp->type != AGTV_INTEGER)
-        {
-            ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("end vertex argument must be a vertex or the integer id")));
-        }
-        vlelctx->path_function = VLE_FUNCTION_PATHS_BETWEEN;
-        vlelctx->veid = agtv_temp->val.int_value;
-    }
+    // get the VLE edge prototype 
+    agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(3), AGTV_EDGE, true);
 
-    /* get the VLE edge prototype */
-    agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(3),
-                                 AGTV_EDGE, true);
+    // get the edge prototype's property conditions 
+    agtype_value *agtv_object = GET_AGTYPE_VALUE_OBJECT_VALUE(agtv_temp, "properties");
+    // store the properties as an agtype 
+    path_ctx->edge_property_constraint = agtype_value_to_agtype(agtv_object);
 
-    /* get the edge prototype's property conditions */
-    agtv_object = GET_AGTYPE_VALUE_OBJECT_VALUE(agtv_temp, "properties");
-    /* store the properties as an agtype */
-    vlelctx->edge_property_constraint = agtype_value_to_agtype(agtv_object);
-
-    /* get the edge prototype's label name */
+    // get the edge prototype's label name 
     agtv_temp = GET_AGTYPE_VALUE_OBJECT_VALUE(agtv_temp, "label");
-    if (agtv_temp->type == AGTV_STRING &&
-        agtv_temp->val.string.len != 0)
-    {
-        vlelctx->edge_label_name = pnstrdup(agtv_temp->val.string.val,
-                                            agtv_temp->val.string.len);
-    }
+    if (agtv_temp->type == AGTV_STRING && agtv_temp->val.string.len != 0)
+        path_ctx->edge_label_name = pnstrdup(agtv_temp->val.string.val, agtv_temp->val.string.len);
     else
-    {
-        vlelctx->edge_label_name = NULL;
+        path_ctx->edge_label_name = NULL;
+
+    // get the left range index 
+    if (PG_ARGISNULL(4) || is_agtype_null(AG_GET_ARG_AGTYPE_P(4))) {
+        path_ctx->lidx = 1;
+    } else {
+        agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(4), AGTV_INTEGER, true);
+        path_ctx->lidx = agtv_temp->val.int_value;
     }
 
-    /* get the left range index */
-    if (PG_ARGISNULL(4) || is_agtype_null(AG_GET_ARG_AGTYPE_P(4)))
-    {
-        vlelctx->lidx = 1;
+    // get the right range index. NULL means infinite 
+    if (PG_ARGISNULL(5) || is_agtype_null(AG_GET_ARG_AGTYPE_P(5))) {
+        path_ctx->uidx_infinite = true;
+        path_ctx->uidx = 0;
+    } else {
+        agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(5), AGTV_INTEGER, true);
+        path_ctx->uidx = agtv_temp->val.int_value;
+        path_ctx->uidx_infinite = false;
     }
-    else
-    {
-        agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(4),
-                                     AGTV_INTEGER, true);
-        vlelctx->lidx = agtv_temp->val.int_value;
-    }
+    // get edge direction 
+    agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(6), AGTV_INTEGER, true);
+    path_ctx->edge_direction = agtv_temp->val.int_value;
 
-    /* get the right range index. NULL means infinite */
-    if (PG_ARGISNULL(5) || is_agtype_null(AG_GET_ARG_AGTYPE_P(5)))
-    {
-        vlelctx->uidx_infinite = true;
-        vlelctx->uidx = 0;
-    }
-    else
-    {
-        agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(5),
-                                     AGTV_INTEGER, true);
-        vlelctx->uidx = agtv_temp->val.int_value;
-        vlelctx->uidx_infinite = false;
-    }
-    /* get edge direction */
-    agtv_temp = get_agtype_value("age_vle", AG_GET_ARG_AGTYPE_P(6),
-                                 AGTV_INTEGER, true);
-    vlelctx->edge_direction = agtv_temp->val.int_value;
+    create_VLE_local_state_hashtable(path_ctx);
 
-    /* create the local state hashtable */
-    create_VLE_local_state_hashtable(vlelctx);
+    // initialize the dfs stacks 
+    path_ctx->dfs_vertex_stack = new_graphid_stack();
+    path_ctx->dfs_edge_stack = new_graphid_stack();
+    path_ctx->dfs_path_stack = new_graphid_stack();
 
-    /* initialize the dfs stacks */
-    vlelctx->dfs_vertex_stack = new_graphid_stack();
-    vlelctx->dfs_edge_stack = new_graphid_stack();
-    vlelctx->dfs_path_stack = new_graphid_stack();
+    // load in the starting edge(s) 
+    load_initial_dfs_stacks(path_ctx);
 
-    /* load in the starting edge(s) */
-    load_initial_dfs_stacks(vlelctx);
+    path_ctx->next = NULL;
 
-    /* this is a new one so nothing follows it */
-    vlelctx->next = NULL;
-
-    /* mark as dirty */
-    vlelctx->is_dirty = true;
-
-    /* if this is to be cached, cache it */
-    if (use_cache == true)
-    {
-        cache_path_finding_context(vlelctx);
-    }
-
-    /* switch back to the original context */
     MemoryContextSwitchTo(oldctx);
 
-    /* return the new context */
-    return vlelctx;
+    return path_ctx;
 }
 
 /*
  * Helper function to get the specified edge's state. If it does not find it, it
  * creates and initializes it.
  */
-static edge_state_entry *get_edge_state(path_finding_context *vlelctx,
-                                        graphid edge_id)
-{
+static edge_state_entry *get_edge_state(path_finding_context *path_ctx, graphid edge_id) {
     edge_state_entry *ese = NULL;
     bool found = false;
 
-    /* retrieve the edge_state_entry from the edge state hashtable */
-    ese = (edge_state_entry *)hash_search(vlelctx->edge_state_hashtable,
-                                          (void *)&edge_id, HASH_ENTER, &found);
+    // retrieve the edge_state_entry from the edge state hashtable 
+    ese = (edge_state_entry *)hash_search(path_ctx->edge_state_hashtable, (void *)&edge_id, HASH_ENTER, &found);
 
-    /* if it isn't found, it needs to be created and initialized */
-    if (!found)
-    {
-        /* the edge id is also the hash key for resolving collisions */
+    // if it isn't found, it needs to be created and initialized 
+    if (!found) {
+        // the edge id is also the hash key for resolving collisions 
         ese->edge_id = edge_id;
         ese->used_in_path = false;
         ese->has_been_matched = false;
@@ -824,13 +362,12 @@ static edge_state_entry *get_edge_state(path_finding_context *vlelctx,
  * Helper function to get the id of the next vertex to move to. This is to
  * simplify finding the next vertex due to the VLE edge's direction.
  */
-static graphid get_next_vertex(path_finding_context *vlelctx, edge_entry *ee)
+static graphid get_next_vertex(path_finding_context *path_ctx, edge_entry *ee)
 {
     graphid terminal_vertex_id;
 
-    /* get the result based on the specified VLE edge direction */
-    switch (vlelctx->edge_direction)
-    {
+    // get the result based on the specified VLE edge direction 
+    switch (path_ctx->edge_direction) {
         case CYPHER_REL_DIR_RIGHT:
             terminal_vertex_id = get_edge_entry_end_vertex_id(ee);
             break;
@@ -844,26 +381,20 @@ static graphid get_next_vertex(path_finding_context *vlelctx, edge_entry *ee)
             ListGraphId *vertex_stack = NULL;
             graphid parent_vertex_id;
 
-            vertex_stack = vlelctx->dfs_vertex_stack;
+            vertex_stack = path_ctx->dfs_vertex_stack;
             /*
              * Get the parent vertex of this edge. When we are looking at edges
              * as un-directional, where we go to next depends on where we came
              * from. This is because we can go against an edge.
              */
             parent_vertex_id = PEEK_GRAPHID_STACK(vertex_stack);
-            /* find the terminal vertex */
+            // find the terminal vertex 
             if (get_edge_entry_start_vertex_id(ee) == parent_vertex_id)
-            {
                 terminal_vertex_id = get_edge_entry_end_vertex_id(ee);
-            }
             else if (get_edge_entry_end_vertex_id(ee) == parent_vertex_id)
-            {
                 terminal_vertex_id = get_edge_entry_start_vertex_id(ee);
-            }
             else
-            {
                 elog(ERROR, "get_next_vertex: no parent match");
-            }
 
             break;
         }
@@ -887,34 +418,27 @@ static graphid get_next_vertex(path_finding_context *vlelctx, edge_entry *ee)
  * the stack. Each successive invocation within the SRF will then look for the
  * next available path until there aren't any left.
  */
-static bool dfs_find_a_path_between(path_finding_context *vlelctx)
+static bool dfs_find_a_path_between(path_finding_context *path_ctx)
 {
-    ListGraphId *vertex_stack = NULL;
-    ListGraphId *edge_stack = NULL;
-    ListGraphId *path_stack = NULL;
-    graphid end_vertex_id;
+    Assert(path_ctx);
 
-    Assert(vlelctx != NULL);
+    ListGraphId *vertex_stack = path_ctx->dfs_vertex_stack;
+    ListGraphId *edge_stack = path_ctx->dfs_edge_stack;
+    ListGraphId *path_stack = path_ctx->dfs_path_stack;
+    graphid end_vertex_id = path_ctx->veid;
 
-    /* for ease of reading */
-    vertex_stack = vlelctx->dfs_vertex_stack;
-    edge_stack = vlelctx->dfs_edge_stack;
-    path_stack = vlelctx->dfs_path_stack;
-    end_vertex_id = vlelctx->veid;
-
-    /* while we have edges to process */
-    while (!(IS_GRAPHID_STACK_EMPTY(edge_stack)))
-    {
+    // while we have edges to process 
+    while (!(IS_GRAPHID_STACK_EMPTY(edge_stack))) {
         graphid edge_id;
         graphid next_vertex_id;
         edge_state_entry *ese = NULL;
         edge_entry *ee = NULL;
         bool found = false;
 
-        /* get an edge, but leave it on the stack for now */
+        // get an edge, but leave it on the stack for now 
         edge_id = PEEK_GRAPHID_STACK(edge_stack);
-        /* get the edge's state */
-        ese = get_edge_state(vlelctx, edge_id);
+        // get the edge's state 
+        ese = get_edge_state(path_ctx, edge_id);
         /*
          * If the edge is already in use, it means that the edge is in the path.
          * So, we need to see if it is the last path entry (we are backing up -
@@ -923,22 +447,20 @@ static bool dfs_find_a_path_between(path_finding_context *vlelctx)
          * in the path (loop - we need to remove the edge from the edge stack
          * and start with the next edge).
          */
-        if (ese->used_in_path)
-        {
+        if (ese->used_in_path) {
             graphid path_edge_id;
 
-            /* get the edge id on the top of the path stack (last edge) */
+            // get the edge id on the top of the path stack (last edge) 
             path_edge_id = PEEK_GRAPHID_STACK(path_stack);
             /*
              * If the ids are the same, we're backing up. So, remove it from the
              * path stack and reset used_in_path.
              */
-            if (edge_id == path_edge_id)
-            {
+            if (edge_id == path_edge_id) {
                 pop_graphid_stack(path_stack);
                 ese->used_in_path = false;
             }
-            /* now remove it from the edge stack */
+            // now remove it from the edge stack 
             pop_graphid_stack(edge_stack);
             /*
              * Remove its source vertex, if we are looking at edges as
@@ -946,11 +468,9 @@ static bool dfs_find_a_path_between(path_finding_context *vlelctx)
              * edge_direction is CYPHER_REL_DIR_NONE. This is to save space
              * and time.
              */
-            if (vlelctx->edge_direction == CYPHER_REL_DIR_NONE)
-            {
+            if (path_ctx->edge_direction == CYPHER_REL_DIR_NONE)
                 pop_graphid_stack(vertex_stack);
-            }
-            /* move to the next edge */
+            // move to the next edge 
             continue;
         }
 
@@ -961,52 +481,39 @@ static bool dfs_find_a_path_between(path_finding_context *vlelctx)
         ese->used_in_path = true;
         push_graphid_stack(path_stack, edge_id);
 
-        /* now get the edge entry so we can get the next vertex to move to */
-        ee = get_edge_entry(vlelctx->ggctx, edge_id);
-        next_vertex_id = get_next_vertex(vlelctx, ee);
+        // now get the edge entry so we can get the next vertex to move to 
+        ee = get_edge_entry(path_ctx->ggctx, edge_id);
+        next_vertex_id = get_next_vertex(path_ctx, ee);
 
         /*
          * Is this the end of a path that meets our requirements? Is its length
          * within the bounds specified?
          */
-        if (next_vertex_id == end_vertex_id &&
-            get_stack_size(path_stack) >= vlelctx->lidx &&
-            (vlelctx->uidx_infinite ||
-             get_stack_size(path_stack) <= vlelctx->uidx))
-        {
-            /* we found one */
+        if (next_vertex_id == end_vertex_id && get_stack_size(path_stack) >= path_ctx->lidx &&
+            (path_ctx->uidx_infinite || get_stack_size(path_stack) <= path_ctx->uidx))
             found = true;
-        }
-        /*
+        
+	/*
          * If we have found the end vertex but, we are not within our upper
          * bounds, we need to back up. We still need to continue traversing
          * the graph if we aren't within our lower bounds, though.
          */
-        if (next_vertex_id == end_vertex_id &&
-            !vlelctx->uidx_infinite &&
-            get_stack_size(path_stack) > vlelctx->uidx)
-        {
+        if (next_vertex_id == end_vertex_id && !path_ctx->uidx_infinite && get_stack_size(path_stack) > path_ctx->uidx)
             continue;
-        }
 
-        /* add in the edges for the next vertex if we won't exceed the bounds */
-        if (vlelctx->uidx_infinite ||
-            get_stack_size(path_stack) < vlelctx->uidx)
-        {
-            add_valid_vertex_edges(vlelctx, next_vertex_id);
-        }
+        // add in the edges for the next vertex if we won't exceed the bounds 
+        if (path_ctx->uidx_infinite || get_stack_size(path_stack) < path_ctx->uidx)
+            add_valid_vertex_edges(path_ctx, next_vertex_id);
 
         if (found)
-        {
             return true;
-        }
     }
 
     return false;
 }
 
 /*
- * Helper function to find one path FROM a start vertex.
+ * find one path from a start vertex.
  *
  * Note: On the very first entry into this function, the starting vertex's edges
  * should have already been loaded into the edge stack (this should have been
@@ -1017,32 +524,27 @@ static bool dfs_find_a_path_between(path_finding_context *vlelctx)
  * the stack. Each successive invocation within the SRF will then look for the
  * next available path until there aren't any left.
  */
-static bool dfs_find_a_path_from(path_finding_context *vlelctx)
+static bool dfs_find_a_path_from(path_finding_context *path_ctx)
 {
-    ListGraphId *vertex_stack = NULL;
-    ListGraphId *edge_stack = NULL;
-    ListGraphId *path_stack = NULL;
+    Assert(path_ctx);
 
-    Assert(vlelctx != NULL);
+    // for ease of reading 
+    ListGraphId *vertex_stack = path_ctx->dfs_vertex_stack;
+    ListGraphId *edge_stack = path_ctx->dfs_edge_stack;
+    ListGraphId *path_stack = path_ctx->dfs_path_stack;
 
-    /* for ease of reading */
-    vertex_stack = vlelctx->dfs_vertex_stack;
-    edge_stack = vlelctx->dfs_edge_stack;
-    path_stack = vlelctx->dfs_path_stack;
-
-    /* while we have edges to process */
-    while (!(IS_GRAPHID_STACK_EMPTY(edge_stack)))
-    {
+    // while we have edges to process 
+    while (!IS_GRAPHID_STACK_EMPTY(edge_stack)) {
         graphid edge_id;
         graphid next_vertex_id;
         edge_state_entry *ese = NULL;
         edge_entry *ee = NULL;
         bool found = false;
 
-        /* get an edge, but leave it on the stack for now */
+        // get an edge, but leave it on the stack for now 
         edge_id = PEEK_GRAPHID_STACK(edge_stack);
-        /* get the edge's state */
-        ese = get_edge_state(vlelctx, edge_id);
+        // get the edge's state 
+        ese = get_edge_state(path_ctx, edge_id);
         /*
          * If the edge is already in use, it means that the edge is in the path.
          * So, we need to see if it is the last path entry (we are backing up -
@@ -1051,22 +553,20 @@ static bool dfs_find_a_path_from(path_finding_context *vlelctx)
          * in the path (loop - we need to remove the edge from the edge stack
          * and start with the next edge).
          */
-        if (ese->used_in_path)
-        {
+        if (ese->used_in_path) {
             graphid path_edge_id;
 
-            /* get the edge id on the top of the path stack (last edge) */
+            // get the edge id on the top of the path stack (last edge) 
             path_edge_id = PEEK_GRAPHID_STACK(path_stack);
             /*
              * If the ids are the same, we're backing up. So, remove it from the
              * path stack and reset used_in_path.
              */
-            if (edge_id == path_edge_id)
-            {
+            if (edge_id == path_edge_id) {
                 pop_graphid_stack(path_stack);
                 ese->used_in_path = false;
             }
-            /* now remove it from the edge stack */
+            // now remove it from the edge stack 
             pop_graphid_stack(edge_stack);
             /*
              * Remove its source vertex, if we are looking at edges as
@@ -1074,11 +574,9 @@ static bool dfs_find_a_path_from(path_finding_context *vlelctx)
              * edge_direction is CYPHER_REL_DIR_NONE. This is to save space
              * and time.
              */
-            if (vlelctx->edge_direction == CYPHER_REL_DIR_NONE)
-            {
+            if (path_ctx->edge_direction == CYPHER_REL_DIR_NONE)
                 pop_graphid_stack(vertex_stack);
-            }
-            /* move to the next edge */
+            // move to the next edge 
             continue;
         }
 
@@ -1089,33 +587,22 @@ static bool dfs_find_a_path_from(path_finding_context *vlelctx)
         ese->used_in_path = true;
         push_graphid_stack(path_stack, edge_id);
 
-        /* now get the edge entry so we can get the next vertex to move to */
-        ee = get_edge_entry(vlelctx->ggctx, edge_id);
-        next_vertex_id = get_next_vertex(vlelctx, ee);
+        // now get the edge entry so we can get the next vertex to move to 
+        ee = get_edge_entry(path_ctx->ggctx, edge_id);
+        next_vertex_id = get_next_vertex(path_ctx, ee);
 
         /*
-         * Is this a path that meets our requirements? Is its length within the
-         * bounds specified?
+         * Is this a path that meets our requirements? Is its length within the * bounds specified?
          */
-        if (get_stack_size(path_stack) >= vlelctx->lidx &&
-            (vlelctx->uidx_infinite ||
-             get_stack_size(path_stack) <= vlelctx->uidx))
-        {
-            /* we found one */
+        if (get_stack_size(path_stack) >= path_ctx->lidx && (path_ctx->uidx_infinite || get_stack_size(path_stack) <= path_ctx->uidx))
             found = true;
-        }
 
-        /* add in the edges for the next vertex if we won't exceed the bounds */
-        if (vlelctx->uidx_infinite ||
-            get_stack_size(path_stack) < vlelctx->uidx)
-        {
-            add_valid_vertex_edges(vlelctx, next_vertex_id);
-        }
+        // add in the edges for the next vertex if we won't exceed the bounds 
+        if (path_ctx->uidx_infinite || get_stack_size(path_stack) < path_ctx->uidx)
+            add_valid_vertex_edges(path_ctx, next_vertex_id);
 
         if (found)
-        {
             return true;
-        }
     }
 
     return false;
@@ -1127,178 +614,102 @@ static bool dfs_find_a_path_from(path_finding_context *vlelctx)
  * smaller sized lists. But, it is O(n) so it should only be used for small
  * path_stacks and where appropriate.
  */
-static bool is_edge_in_path(path_finding_context *vlelctx, graphid edge_id)
-{
-    GraphIdNode *edge = NULL;
+static bool is_edge_in_path(path_finding_context *path_ctx, graphid edge_id) {
+    GraphIdNode *edge = peek_stack_head(path_ctx->dfs_path_stack);
 
-    /* start at the top of the stack */
-    edge = peek_stack_head(vlelctx->dfs_path_stack);
-
-    /* go through the path stack, return true if we find the edge */
-    while (edge != NULL)
-    {
+    // go through the path stack, return true if we find the edge 
+    while (edge) {
         if (get_graphid(edge) == edge_id)
-        {
             return true;
-        }
-        /* get the next stack element */
+
         edge = next_GraphIdNode(edge);
     }
-    /* we didn't find it if we get here */
+
     return false;
 }
 
-/*
- * Helper function to add in valid vertex edges as part of the dfs path
- * algorithm. What constitutes a valid edge is the following -
- *
- *     1) Edge matches the correct direction specified.
- *     2) Edge is not currently in the path.
- *     3) Edge matches minimum edge properties specified.
- *
- * Note: The vertex must exist.
- */
-static void add_valid_vertex_edges(path_finding_context *vlelctx,
-                                   graphid vertex_id)
-{
-    ListGraphId *vertex_stack = NULL;
-    ListGraphId *edge_stack = NULL;
+// add in valid vertex edges as part of the dfs path algorithm.
+static void add_valid_vertex_edges(path_finding_context *path_ctx, graphid vertex_id) {
     ListGraphId *edges = NULL;
-    vertex_entry *ve = NULL;
-    GraphIdNode *edge_in = NULL;
+
+    // get the vertex entry 
+    vertex_entry *ve = get_vertex_entry(path_ctx->ggctx, vertex_id);
+    Assert(ve);
+
+    ListGraphId *vertex_stack = path_ctx->dfs_vertex_stack;
+    ListGraphId *edge_stack = path_ctx->dfs_edge_stack;
+
+    // set to the first edge for each edge list for the specified direction 
     GraphIdNode *edge_out = NULL;
-    GraphIdNode *edge_self = NULL;
-
-    /* get the vertex entry */
-    ve = get_vertex_entry(vlelctx->ggctx, vertex_id);
-    /* there better be a valid vertex */
-    if (ve == NULL)
-    {
-        elog(ERROR, "add_valid_vertex_edges: no vertex found");
-    }
-
-    /* point to stacks */
-    vertex_stack = vlelctx->dfs_vertex_stack;
-    edge_stack = vlelctx->dfs_edge_stack;
-
-    /* set to the first edge for each edge list for the specified direction */
-    if (vlelctx->edge_direction == CYPHER_REL_DIR_RIGHT ||
-        vlelctx->edge_direction == CYPHER_REL_DIR_NONE)
-    {
+    if (path_ctx->edge_direction != CYPHER_REL_DIR_LEFT) {
         edges = get_vertex_entry_edges_out(ve);
         edge_out = (edges != NULL) ? get_list_head(edges) : NULL;
     }
-    if (vlelctx->edge_direction == CYPHER_REL_DIR_LEFT ||
-        vlelctx->edge_direction == CYPHER_REL_DIR_NONE)
-    {
+
+    GraphIdNode *edge_in = NULL;
+    if (path_ctx->edge_direction != CYPHER_REL_DIR_RIGHT) {
         edges = get_vertex_entry_edges_in(ve);
         edge_in = (edges != NULL) ? get_list_head(edges) : NULL;
     }
-    /* set to the first selfloop edge */
-    edges = get_vertex_entry_edges_self(ve);
-    edge_self = (edges != NULL) ? get_list_head(edges) : NULL;
 
-    /* add in valid vertex edges */
-    while (edge_out != NULL || edge_in != NULL || edge_self != NULL)
-    {
-        edge_entry *ee = NULL;
-        edge_state_entry *ese = NULL;
+    // set to the first selfloop edge 
+    edges = get_vertex_entry_edges_self(ve);
+    GraphIdNode *edge_self = (edges != NULL) ? get_list_head(edges) : NULL;
+
+    // add in valid vertex edges 
+    while (edge_out || edge_in || edge_self) {
         graphid edge_id;
 
-        /* get the edge_id from the next available edge*/
-        if (edge_out != NULL)
-        {
+        // get the edge_id from the next available edge
+        if (edge_out)
             edge_id = get_graphid(edge_out);
-        }
-        else if (edge_in != NULL)
-        {
+        else if (edge_in)
             edge_id = get_graphid(edge_in);
-        }
         else
-        {
             edge_id = get_graphid(edge_self);
-        }
 
-        /*
-         * This is a fast existence check, relative to the hash search, for when
-         * the path stack is small. If the edge is in the path, we skip it.
-         */
-        if (get_stack_size(vlelctx->dfs_path_stack) < 10 &&
-            is_edge_in_path(vlelctx, edge_id))
-        {
-            /* set to the next available edge */
-            if (edge_out != NULL)
-            {
-                edge_out = next_GraphIdNode(edge_out);
-            }
-            else if (edge_in != NULL)
-            {
-                edge_in = next_GraphIdNode(edge_in);
-            }
-            else
-            {
-                edge_self = next_GraphIdNode(edge_self);
-            }
-            continue;
-        }
-
-        /* get the edge entry */
-        ee = get_edge_entry(vlelctx->ggctx, edge_id);
-        /* it better exist */
-        if (ee == NULL)
-        {
-            elog(ERROR, "add_valid_vertex_edges: no edge found");
-        }
-        /* get its state */
-        ese = get_edge_state(vlelctx, edge_id);
+        // get the edge entry 
+        edge_entry *ee = get_edge_entry(path_ctx->ggctx, edge_id);
+        Assert(ee);
+            
+        // get its state 
+        edge_state_entry *ese = get_edge_state(path_ctx, edge_id);
         /*
          * Don't add any edges that we have already seen because they will
          * cause a loop to form.
          */
-        if (!ese->used_in_path)
-        {
-            /* validate the edge if it hasn't been already */
-            if (!ese->has_been_matched && is_an_edge_match(vlelctx, ee))
-            {
+        if (!ese->used_in_path) {
+            // validate the edge if it hasn't been already 
+            if (!ese->has_been_matched && is_an_edge_match(path_ctx, ee)) {
                 ese->has_been_matched = true;
                 ese->matched = true;
-            }
-            else if (!ese->has_been_matched)
-            {
+            } else if (!ese->has_been_matched) {
                 ese->has_been_matched = true;
                 ese->matched = false;
             }
-            /* if it is a match, add it */
-            if (ese->has_been_matched && ese->matched)
-            {
+
+            if (ese->has_been_matched && ese->matched) {
                 /*
                  * We need to maintain our source vertex for each edge added
                  * if the edge_direction is CYPHER_REL_DIR_NONE. This is due
                  * to the edges having a fixed direction and the dfs
                  * algorithm working strictly through edges. With an
-                 * un-directional VLE edge, you don't know the vertex that
+                 * un-directional edge, you don't know the vertex that
                  * you just came from. So, we need to store it.
                  */
-                 if (vlelctx->edge_direction == CYPHER_REL_DIR_NONE)
-                 {
+                 if (path_ctx->edge_direction == CYPHER_REL_DIR_NONE)
                      push_graphid_stack(vertex_stack, get_vertex_entry_id(ve));
-                 }
                  push_graphid_stack(edge_stack, edge_id);
             }
         }
-        /* get the next working edge */
-        if (edge_out != NULL)
-        {
+
+        // get the next edge
+        if (edge_out)
             edge_out = next_GraphIdNode(edge_out);
-        }
-        else if (edge_in != NULL)
-        {
+        else if (edge_in)
             edge_in = next_GraphIdNode(edge_in);
-        }
         else
-        {
             edge_self = next_GraphIdNode(edge_self);
-        }
     }
 }
 
@@ -1324,19 +735,16 @@ static path_container *create_path_container(int64 path_size)
      */
     container_size_bytes = sizeof(graphid) * (path_size + 4);
 
-    /* allocate the container */
-    vpc = palloc0(container_size_bytes);
+    // allocate the container 
+    vpc = palloc(container_size_bytes);
 
-    /* initialze the PG headers */
+    // initialze the PG headers 
     SET_VARSIZE(vpc, container_size_bytes);
 
-    /* initialize the container */
+    // initialize the container 
     vpc->header = AGT_FBINARY | AGT_FBINARY_TYPE_VLE_PATH;
     vpc->graphid_array_size = path_size;
     vpc->container_size_bytes = container_size_bytes;
-
-    /* the graphid array is already zeroed out */
-    /* all of the other fields are set by the caller */
 
     return vpc;
 }
@@ -1361,353 +769,191 @@ static path_container *create_path_container(int64 path_size)
  *     The total number of elements in the array.
  *
  *     The total size of the container for copying.
- *
- * Note: Remember to pfree it when done. Even though it should be destroyed on
- *       exiting the SRF context.
  */
-
-static path_container *build_path_container(path_finding_context *vlelctx)
-{
-    ListGraphId *stack = vlelctx->dfs_path_stack;
-    path_container *vpc = NULL;
+static path_container *build_path_container(path_finding_context *path_ctx) {
+    ListGraphId *stack = path_ctx->dfs_path_stack;
     graphid *graphid_array = NULL;
     GraphIdNode *edge = NULL;
     graphid vid = 0;
-    int index = 0;
-    int ssize = 0;
 
-    if (stack == NULL)
-    {
+    if (!stack)
         return NULL;
-    }
 
-    /* allocate the graphid array */
-    ssize = get_stack_size(stack);
+    int ssize = get_stack_size(stack);
 
     /*
      * Create the container. Note that the path size will always be 2 times the
      * number of edges plus 1 -> (u)-[e]-(v)
      */
-    vpc = create_path_container((ssize * 2) + 1);
+    path_container *vpc = create_path_container((ssize * 2) + 1);
 
-    /* set the graph_oid */
-    vpc->graph_oid = vlelctx->graph_oid;
+    // set the graph_oid 
+    vpc->graph_oid = path_ctx->graph_oid;
 
-    /* get the graphid_array from the container */
+    // get the graphid_array from the container 
     graphid_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
 
-    /* get and store the start vertex */
-    vid = vlelctx->vsid;
+    // get and store the start vertex 
+    vid = path_ctx->vsid;
     graphid_array[0] = vid;
 
-    /* get the head of the stack */
+    // get the head of the stack 
     edge = peek_stack_head(stack);
 
     /*
      * We need to fill in the array from the back to the front. This is due
-     * to the order of the path stack - last in first out. Remember that the
-     * last entry is a vertex.
+     * to the order of the path stack - last in first out.
      */
-    index = vpc->graphid_array_size - 2;
+    int index = vpc->graphid_array_size - 2;
 
-    /* copy while we have an edge to copy */
-    while (edge != NULL)
-    {
-        /* 0 is the vsid, we should never get here */
+    // copy while we have an edge to copy 
+    while (edge) {
+        // 0 is the vsid, we should never get here 
         Assert(index > 0);
 
-        /* store and set to the next edge */
+        // store and set to the next edge 
         graphid_array[index] = get_graphid(edge);
         edge = next_GraphIdNode(edge);
 
-        /* we need to skip over the interior vertices */
+        // we need to skip over the interior vertices 
         index -= 2;
     }
 
-    /* now add in the interior vertices, starting from the first edge */
-    for (index = 1; index < vpc->graphid_array_size - 1; index += 2)
-    {
-        edge_entry *ee = NULL;
-
-        ee = get_edge_entry(vlelctx->ggctx, graphid_array[index]);
-        vid = (vid == get_edge_entry_start_vertex_id(ee)) ?
-                   get_edge_entry_end_vertex_id(ee) :
-                   get_edge_entry_start_vertex_id(ee);
-        graphid_array[index+1] = vid;
+    // now add in the interior vertices, starting from the first edge 
+    for (index = 1; index < vpc->graphid_array_size - 1; index += 2) {
+        edge_entry *ee = get_edge_entry(path_ctx->ggctx, graphid_array[index]);
+        
+	vid = (vid == get_edge_entry_start_vertex_id(ee)) ? get_edge_entry_end_vertex_id(ee) : get_edge_entry_start_vertex_id(ee);
+        
+	graphid_array[index+1] = vid;
     }
 
-    /* return the container */
+    // return the container 
     return vpc;
 }
 
-/* helper function to build a VPC for just the start vertex */
-static path_container *build_VLE_zero_container(path_finding_context *vlelctx)
-{
-    ListGraphId *stack = vlelctx->dfs_path_stack;
-    path_container *vpc = NULL;
-    graphid *graphid_array = NULL;
-    graphid vid = 0;
+// helper function to build a VPC for just the start vertex 
 
-    /* we should have an empty stack */
-    Assert(get_stack_size(stack) == 0);
-
-    /*
-     * Create the container. Note that the path size will always be 1 as this is
-     * just the starting vertex.
-     */
-    vpc = create_path_container(1);
-
-    /* set the graph_oid */
-    vpc->graph_oid = vlelctx->graph_oid;
-
-    /* get the graphid_array from the container */
-    graphid_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
-
-    /* get and store the start vertex */
-    vid = vlelctx->vsid;
-    graphid_array[0] = vid;
-
-    return vpc;
-}
-
-/*
- * Helper function to build an AGTV_ARRAY of edges from an array of graphids.
- *
- * Note: You should free the array when done. Although, it should be freed
- *       when the context is destroyed from the return of the SRF call.
- */
-static agtype_value *build_edge_list(path_container *vpc)
-{
-    graph_context *ggctx = NULL;
+// build an AGTV_ARRAY of edges from an array of graphids.
+static agtype_value *build_edge_list(path_container *vpc) {
     agtype_in_state edges_result;
-    Oid graph_oid = InvalidOid;
-    graphid *graphid_array = NULL;
-    int64 graphid_array_size = 0;
-    int index = 0;
 
-    /* get the graph_oid */
-    graph_oid = vpc->graph_oid;
-
-    /* get the GRAPH global context for this graph */
-    ggctx = find_graph_context(graph_oid);
-    /* verify we got a global context */
+    // get the graph context
+    graph_context *ggctx = find_graph_context(vpc->graph_oid);
     Assert(ggctx != NULL);
 
-    /* get the graphid_array and size */
-    graphid_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
-    graphid_array_size = vpc->graphid_array_size;
+    // get the graphid_array and size 
+    graphid *graphid_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
+    int graphid_array_size = vpc->graphid_array_size;
 
-    /* initialize our agtype array */
+    // initialize our agtype array 
     MemSet(&edges_result, 0, sizeof(agtype_in_state));
-    edges_result.res = push_agtype_value(&edges_result.parse_state,
-                                         WAGT_BEGIN_ARRAY, NULL);
+    edges_result.res = push_agtype_value(&edges_result.parse_state, WAGT_BEGIN_ARRAY, NULL);
 
-    for (index = 1; index < graphid_array_size - 1; index += 2)
-    {
-        char *label_name = NULL;
-        edge_entry *ee = NULL;
-        agtype_value *agtv_edge = NULL;
-
-        /* get the edge entry from the hashtable */
-        ee = get_edge_entry(ggctx, graphid_array[index]);
-        /* get the label name from the oid */
-        label_name = get_rel_name(get_edge_entry_label_table_oid(ee));
-        /* reconstruct the edge */
-        agtv_edge = agtype_value_build_edge(get_edge_entry_id(ee), label_name,
+    for (int index = 1; index < graphid_array_size - 1; index += 2) {
+        // get the edge entry from the hashtable 
+        edge_entry *ee = get_edge_entry(ggctx, graphid_array[index]);
+        // get the label name from the oid 
+        char *label_name = get_rel_name(get_edge_entry_label_table_oid(ee));
+        // reconstruct the edge 
+        agtype_value *agtv_edge = agtype_value_build_edge(get_edge_entry_id(ee), label_name,
                                             get_edge_entry_end_vertex_id(ee),
                                             get_edge_entry_start_vertex_id(ee),
                                             get_edge_entry_properties(ee));
-        /* push the edge*/
-        edges_result.res = push_agtype_value(&edges_result.parse_state,
-                                             WAGT_ELEM, agtv_edge);
+        // push the edge
+        edges_result.res = push_agtype_value(&edges_result.parse_state, WAGT_ELEM, agtv_edge);
     }
 
-    /* close our agtype array */
-    edges_result.res = push_agtype_value(&edges_result.parse_state,
-                                         WAGT_END_ARRAY, NULL);
+    edges_result.res = push_agtype_value(&edges_result.parse_state, WAGT_END_ARRAY, NULL);
 
-    /* make it an array */
-    edges_result.res->type = AGTV_ARRAY;
-
-    /* return it */
     return edges_result.res;
 }
 
-/*
- * Helper function to build an array of type AGTV_PATH from an array of
- * graphids.
- *
- * Note: You should free the array when done. Although, it should be freed
- *       when the context is destroyed from the return of the SRF call.
- */
-static agtype_value *build_path(path_container *vpc)
-{
+// Build an array of type AGTV_PATH from an array of graphids.
+static agtype_value *build_path(path_container *vpc) {
     graph_context *ggctx = NULL;
     agtype_in_state path_result;
-    Oid graph_oid = InvalidOid;
-    graphid *graphid_array = NULL;
-    int64 graphid_array_size = 0;
-    int index = 0;
 
-    /* get the graph_oid */
-    graph_oid = vpc->graph_oid;
-
-    /* get the GRAPH global context for this graph */
-    ggctx = find_graph_context(graph_oid);
-    /* verify we got a global context */
+    ggctx = find_graph_context(vpc->graph_oid);
+   
     Assert(ggctx != NULL);
 
-    /* get the graphid_array and size */
-    graphid_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
-    graphid_array_size = vpc->graphid_array_size;
+    graphid *graphid_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
+    int graphid_array_size = vpc->graphid_array_size;
 
-    /* initialize our agtype array */
     MemSet(&path_result, 0, sizeof(agtype_in_state));
-    path_result.res = push_agtype_value(&path_result.parse_state,
-                                        WAGT_BEGIN_ARRAY, NULL);
+    path_result.res = push_agtype_value(&path_result.parse_state, WAGT_BEGIN_ARRAY, NULL);
 
-    for (index = 0; index < graphid_array_size; index += 2)
-    {
-        char *label_name = NULL;
-        vertex_entry *ve = NULL;
-        edge_entry *ee = NULL;
-        agtype_value *agtv_vertex = NULL;
-        agtype_value *agtv_edge = NULL;
+    for (int index = 0; index < graphid_array_size; index += 2) {
+        // get the vertex entry from the hashtable 
+        vertex_entry *ve = get_vertex_entry(ggctx, graphid_array[index]);
+        char *label_name = get_rel_name(get_vertex_entry_label_table_oid(ve));
+        agtype_value *agtv_vertex = agtype_value_build_vertex(get_vertex_entry_id(ve), label_name, get_vertex_entry_properties(ve));
+        path_result.res = push_agtype_value(&path_result.parse_state, WAGT_ELEM, agtv_vertex);
 
-        /* get the vertex entry from the hashtable */
-        ve = get_vertex_entry(ggctx, graphid_array[index]);
-        /* get the label name from the oid */
-        label_name = get_rel_name(get_vertex_entry_label_table_oid(ve));
-        /* reconstruct the vertex */
-        agtv_vertex = agtype_value_build_vertex(get_vertex_entry_id(ve),
-                                                label_name,
-                                                get_vertex_entry_properties(ve));
-        /* push the vertex */
-        path_result.res = push_agtype_value(&path_result.parse_state, WAGT_ELEM,
-                                            agtv_vertex);
-
-        /*
-         * Remember that we have more vertices than edges. So, we need to check
-         * if the above vertex was the last vertex in the path.
-         */
         if (index + 1 >= graphid_array_size)
-        {
             break;
-        }
 
-        /* get the edge entry from the hashtable */
-        ee = get_edge_entry(ggctx, graphid_array[index+1]);
-        /* get the label name from the oid */
+        // get the edge entry from the hashtable 
+        edge_entry *ee = get_edge_entry(ggctx, graphid_array[index+1]);
+        // get the label name from the oid 
         label_name = get_rel_name(get_edge_entry_label_table_oid(ee));
-        /* reconstruct the edge */
-        agtv_edge = agtype_value_build_edge(get_edge_entry_id(ee), label_name,
+        // reconstruct the edge 
+        agtype_value *agtv_edge = agtype_value_build_edge(get_edge_entry_id(ee), label_name,
                                             get_edge_entry_end_vertex_id(ee),
                                             get_edge_entry_start_vertex_id(ee),
                                             get_edge_entry_properties(ee));
-        /* push the edge*/
-        path_result.res = push_agtype_value(&path_result.parse_state, WAGT_ELEM,
-                                            agtv_edge);
+        // push the edge
+        path_result.res = push_agtype_value(&path_result.parse_state, WAGT_ELEM, agtv_edge);
     }
 
-    /* close our agtype array */
-    path_result.res = push_agtype_value(&path_result.parse_state,
-                                        WAGT_END_ARRAY, NULL);
+    // close our agtype array 
+    path_result.res = push_agtype_value(&path_result.parse_state, WAGT_END_ARRAY, NULL);
 
-    /* make it a path */
     path_result.res->type = AGTV_PATH;
 
-    /* return the path */
     return path_result.res;
 }
 
 /*
- * All front facing PG and exposed functions below
- */
-
-/*
- * PG VLE function that takes the following input and returns a row called edges
+ * function that takes the following input and returns a row called edges
  * of type agtype BINARY path_container (this is an internal structure for
  * returning a graphid array of the path. You need to use internal routines to
  * properly use this data) -
  *
  *     0 - agtype REQUIRED (graph name as string)
- *                 Note: This is automatically added by transform_FuncCall.
- *
- *     1 - agtype OPTIONAL (start vertex as a vertex or the integer id)
- *                 Note: Leaving this NULL switches the path algorithm from
- *                       VLE_FUNCTION_PATHS_BETWEEN to VLE_FUNCTION_PATHS_TO
+ *     1 - agtype REQUIRED (start vertex as a vertex or the integer id)
  *     2 - agtype OPTIONAL (end vertex as a vertex or the integer id)
- *                 Note: Leaving this NULL switches the path algorithm from
- *                       VLE_FUNCTION_PATHS_BETWEEN to VLE_FUNCTION_PATHS_FROM
- *                       or - if the starting vertex is NULL - from
- *                       VLE_FUNCTION_PATHS_TO to VLE_FUNCTION_PATHS_ALL
  *     3 - agtype REQUIRED (edge prototype to match as an edge)
- *                 Note: Only the label and properties are used. The
- *                       rest is ignored.
  *     4 - agtype OPTIONAL lidx (lower range index)
- *                 Note: 0 itself is currently not supported but here it is
- *                       equivalent to 1.
- *                       A NULL is appropriate here for a 0 lower bound.
  *     5 - agtype OPTIONAL uidx (upper range index)
- *                 Note: A NULL is appropriate here for an infinite upper bound.
  *     6 - agtype REQUIRED edge direction (enum) as an integer. REQUIRED
- *
- * This is a set returning function. This means that the first call sets
- * up the initial structures and then outputs the first row. After that each
- * subsequent call generates one row of output data. PG will continue to call
- * the function until the function tells PG that it doesn't have any more rows
- * to output. At that point, the function needs to clean up all of its data
- * structures that are not meant to last between SRFs.
  */
 PG_FUNCTION_INFO_V1(age_vle);
-
-Datum age_vle(PG_FUNCTION_ARGS)
-{
+Datum age_vle(PG_FUNCTION_ARGS) {
     FuncCallContext *funcctx;
-    path_finding_context *vlelctx = NULL;
-    bool found_a_path = false;
-    bool done = false;
-    bool is_zero_bound = false;
+    bool found_a_path;
     MemoryContext oldctx;
 
-    /* Initialization for the first call to the SRF */
-    if (SRF_IS_FIRSTCALL())
-    {
-        /* all of these arguments need to be non NULL */
-        if (PG_ARGISNULL(0) || /* graph name */
-            PG_ARGISNULL(3) || /* edge prototype */
-            PG_ARGISNULL(6))   /* direction */
-        {
-             ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+    // Initialization for the first call to the SRF 
+    if (SRF_IS_FIRSTCALL()) {
+        // all of these arguments need to be non NULL 
+        if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(3) || PG_ARGISNULL(6))
+             ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("age_vle: invalid NULL argument passed")));
-        }
 
-        /* create a function context for cross-call persistence */
         funcctx = SRF_FIRSTCALL_INIT();
 
-        /* build the local vle context */
-        vlelctx = build_local_vle_context(fcinfo, funcctx);
+        funcctx->user_fctx = build_vle_context(fcinfo, funcctx);
 
-        /*
-         * Point the function call context's user pointer to the local VLE
-         * context just created
-         */
-        funcctx->user_fctx = vlelctx;
+        // if we are starting from zero [*0..x] return an empty path 
+        if (((path_finding_context *)funcctx->user_fctx)->lidx == 0)
+            SRF_RETURN_NEXT(funcctx, PointerGetDatum(build_path_container(funcctx->user_fctx)));
 
-        /* if we are starting from zero [*0..x] flag it */
-        if (vlelctx->lidx == 0)
-        {
-            is_zero_bound = true;
-            done = true;
-        }
     }
 
-    /* stuff done on every call of the function */
+    // stuff done on every call of the function 
     funcctx = SRF_PERCALL_SETUP();
-
-    /* restore our VLE local context */
-    vlelctx = (path_finding_context *)funcctx->user_fctx;
 
     /*
      * All work done in dfs_find_a_path needs to be done in a context that
@@ -1715,204 +961,86 @@ Datum age_vle(PG_FUNCTION_ARGS)
      */
     oldctx = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
-    while (done == false)
+    // find one path based on specific input 
+    switch (((path_finding_context *)funcctx->user_fctx)->path_function)
     {
-        /* find one path based on specific input */
-        switch (vlelctx->path_function)
-        {
-            case VLE_FUNCTION_PATHS_TO:
-            case VLE_FUNCTION_PATHS_BETWEEN:
-                found_a_path = dfs_find_a_path_between(vlelctx);
-                break;
+        case VLE_FUNCTION_PATHS_BETWEEN:
+            found_a_path = dfs_find_a_path_between(funcctx->user_fctx);
+            break;
 
-            case VLE_FUNCTION_PATHS_ALL:
-            case VLE_FUNCTION_PATHS_FROM:
-                found_a_path = dfs_find_a_path_from(vlelctx);
-                break;
-
-            default:
-                found_a_path = false;
-                break;
-        }
-
-        /* if we found a path, or are done, flag it so we can output the data */
-        if (found_a_path == true ||
-            (found_a_path == false && vlelctx->next_vertex == NULL) ||
-            (found_a_path == false &&
-             (vlelctx->path_function == VLE_FUNCTION_PATHS_BETWEEN ||
-              vlelctx->path_function == VLE_FUNCTION_PATHS_FROM)))
-        {
-            done = true;
-        }
-        /* if we need to fetch a new vertex and rerun the find */
-        else if ((vlelctx->path_function == VLE_FUNCTION_PATHS_ALL) ||
-                 (vlelctx->path_function == VLE_FUNCTION_PATHS_TO))
-        {
-            /* get the next start vertex id */
-            vlelctx->vsid = get_graphid(vlelctx->next_vertex);
-
-            /* increment to the next vertex */
-            vlelctx->next_vertex = next_GraphIdNode(vlelctx->next_vertex);
-
-            /* load in the starting edge(s) */
-            load_initial_dfs_stacks(vlelctx);
-
-            /* if we are starting from zero [*0..x] flag it */
-            if (vlelctx->lidx == 0)
-            {
-                is_zero_bound = true;
-                done = true;
-            }
-            /* otherwise we need to loop back around */
-            else
-            {
-                done = false;
-            }
-        }
-        /* we shouldn't get here */
-        else
-        {
-            ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("age_vle() invalid path function")));
-        }
+        case VLE_FUNCTION_PATHS_FROM:
+            found_a_path = dfs_find_a_path_from(funcctx->user_fctx);
+            break;
     }
 
-    /* switch back to a more volatile context */
+
+    // switch back to a more volatile context 
     MemoryContextSwitchTo(oldctx);
 
     /*
      * If we find a path, we need to convert the path_stack into a list that
      * the outside world can use.
      */
-    if (found_a_path || is_zero_bound)
-    {
+    if (found_a_path) {
         path_container *vpc = NULL;
+        Assert(((path_finding_context *)funcctx->user_fctx)->dfs_path_stack > 0);
 
-        /* if this isn't the zero boundary case generate a normal vpc */
-        if (!is_zero_bound)
-        {
-            /* the path_stack should have something in it if we have a path */
-            Assert(vlelctx->dfs_path_stack > 0);
+        /*
+         * Build the graphid array into a path_container from the
+         * path_stack. This will also correct for the path_stack being last
+         * in, first out.
+         */
+        vpc = build_path_container(funcctx->user_fctx);
 
-            /*
-             * Build the graphid array into a path_container from the
-             * path_stack. This will also correct for the path_stack being last
-             * in, first out.
-             */
-            vpc = build_path_container(vlelctx);
-        }
-        /* otherwise, this is the zero boundary case [*0..x] */
-        else
-        {
-            vpc = build_VLE_zero_container(vlelctx);
-        }
-
-        /* return the result and signal that the function is not yet done */
+        // return the result and signal that the function is not yet done 
         SRF_RETURN_NEXT(funcctx, PointerGetDatum(vpc));
-    }
-    /* otherwise, we are done and we need to cleanup and signal done */
-    else
-    {
-        /* mark local context as clean */
-        vlelctx->is_dirty = false;
+    } else {
+	hash_destroy(((path_finding_context *)funcctx->user_fctx)->edge_state_hashtable);
 
-        /* free the local context, if we aren't caching it */
-        if (vlelctx->use_cache == false)
-        {
-            free_path_finding_context(vlelctx);
-        }
-
-        /* signal that we are done */
         SRF_RETURN_DONE(funcctx);
     }
 }
 
-/*
- * Exposed helper function to make an agtype AGTV_PATH from a
- * path_container.
- */
-agtype *agt_materialize_vle_path(agtype *agt_arg_vpc)
-{
-    /* convert the agtype_value to agtype and return it */
-    return agtype_value_to_agtype(agtv_materialize_vle_path(agt_arg_vpc));
+agtype_value *agtv_materialize_vle_path(agtype *agt) {
+    Assert(agt!= NULL);
+    Assert(AGT_ROOT_IS_BINARY(agt));
+    Assert(AGT_ROOT_BINARY_FLAGS(agt) == AGT_FBINARY_TYPE_VLE_PATH);
+
+    return build_path((path_container *)agt);
 }
 
-/*
- * Exposed helper function to make an agtype_value AGTV_PATH from a
- * path_container.
- */
-agtype_value *agtv_materialize_vle_path(agtype *agt_arg_vpc)
-{
-    path_container *vpc = NULL;
-    agtype_value *agtv_path = NULL;
-
-    /* the passed argument should not be NULL */
-    Assert(agt_arg_vpc != NULL);
-
-    /*
-     * The path must be a binary container and the type of the object in the
-     * container must be an AGT_FBINARY_TYPE_VLE_PATH.
-     */
-    Assert(AGT_ROOT_IS_BINARY(agt_arg_vpc));
-    Assert(AGT_ROOT_BINARY_FLAGS(agt_arg_vpc) == AGT_FBINARY_TYPE_VLE_PATH);
-
-    /* get the container */
-    vpc = (path_container *)agt_arg_vpc;
-
-    /* it should not be null */
-    Assert(vpc != NULL);
-
-    /* build the AGTV_PATH from the path_container */
-    agtv_path = build_path(vpc);
-
-    return agtv_path;
-}
-
-/* PG function to match 2 VLE edges */
+// PG function to match 2 VLE edges 
 PG_FUNCTION_INFO_V1(age_match_two_vle_edges);
-
-Datum age_match_two_vle_edges(PG_FUNCTION_ARGS)
-{
-    agtype *agt_arg_vpc = NULL;
+Datum age_match_two_vle_edges(PG_FUNCTION_ARGS) {
+    agtype *agt = NULL;
     path_container *left_path = NULL, *right_path = NULL;
     graphid *left_array, *right_array;
     int left_array_size;
 
-    /* get the path_container argument */
-    agt_arg_vpc = AG_GET_ARG_AGTYPE_P(0);
+    // get the path_container argument 
+    agt = AG_GET_ARG_AGTYPE_P(0);
 
-    if (!AGT_ROOT_IS_BINARY(agt_arg_vpc) ||
-        AGT_ROOT_BINARY_FLAGS(agt_arg_vpc) != AGT_FBINARY_TYPE_VLE_PATH)
-    {
-        ereport(ERROR,
-            (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+    if (!AGT_ROOT_IS_BINARY(agt) || AGT_ROOT_BINARY_FLAGS(agt) != AGT_FBINARY_TYPE_VLE_PATH)
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
             errmsg("argument 1 of age_match_two_vle_edges must be a VLE_Path_Container")));
-    }
 
-    /* cast argument as a VLE_Path_Container and extract graphid array */
-    left_path = (path_container *)agt_arg_vpc;
+    // cast argument as a VLE_Path_Container and extract graphid array 
+    left_path = (path_container *)agt;
     left_array_size = left_path->graphid_array_size;
     left_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(left_path);
 
-    agt_arg_vpc = AG_GET_ARG_AGTYPE_P(1);
+    agt = AG_GET_ARG_AGTYPE_P(1);
 
-    if (!AGT_ROOT_IS_BINARY(agt_arg_vpc) ||
-        AGT_ROOT_BINARY_FLAGS(agt_arg_vpc) != AGT_FBINARY_TYPE_VLE_PATH)
-    {
-        ereport(ERROR,
-            (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+    if (!AGT_ROOT_IS_BINARY(agt) || AGT_ROOT_BINARY_FLAGS(agt) != AGT_FBINARY_TYPE_VLE_PATH)
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
             errmsg("argument 2 of age_match_two_vle_edges must be a VLE_Path_Container")));
-    }
 
-    /* cast argument as a VLE_Path_Container and extract graphid array */
-    right_path = (path_container *)agt_arg_vpc;
+    // cast argument as a VLE_Path_Container and extract graphid array 
+    right_path = (path_container *)agt;
     right_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(right_path);
 
     if (left_array[left_array_size - 1] != right_array[0])
-    {
         PG_RETURN_BOOL(false);
-    }
 
     PG_RETURN_BOOL(true);
 }
@@ -1924,442 +1052,188 @@ Datum age_match_two_vle_edges(PG_FUNCTION_ARGS)
  * vle path.
  */
 PG_FUNCTION_INFO_V1(age_match_vle_edge_to_id_qual);
+Datum age_match_vle_edge_to_id_qual(PG_FUNCTION_ARGS) {
+    Datum *args;
+    bool *nulls;
+    Oid *types;
+    extract_variadic_args(fcinfo, 0, true, &args, &types, &nulls);
 
-Datum age_match_vle_edge_to_id_qual(PG_FUNCTION_ARGS)
-{
-    int nargs = 0;
-    Datum *args = NULL;
-    bool *nulls = NULL;
-    Oid *types = NULL;
-    agtype *agt_arg_vpc = NULL;
-    agtype *edge_id = NULL;
-    agtype *pos_agt = NULL;
-    agtype_value *id, *position;
-    path_container *vle_path = NULL;
-    graphid *array = NULL;
-    bool vle_is_on_left = false;
-    graphid gid = 0;
+    // get the path_container argument 
+    agtype *agt = DATUM_GET_AGTYPE_P(args[0]);
 
-    /* extract argument values */
-    nargs = extract_variadic_args(fcinfo, 0, true, &args, &types, &nulls);
-
-    if (nargs != 3)
-    {
+    if (!AGT_ROOT_IS_BINARY(agt) || AGT_ROOT_BINARY_FLAGS(agt) != AGT_FBINARY_TYPE_VLE_PATH)
         ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                        errmsg("age_match_vle_edge_to_id_qual() invalid number of arguments")));
-    }
-
-    /* the arguments cannot be NULL */
-    if (nulls[0] || nulls[1] || nulls[2])
-    {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("age_match_vle_edge_to_id_qual() arguments must be non NULL")));
-    }
-
-    /* get the path_container argument */
-    agt_arg_vpc = DATUM_GET_AGTYPE_P(args[0]);
-
-    if (!AGT_ROOT_IS_BINARY(agt_arg_vpc) ||
-        AGT_ROOT_BINARY_FLAGS(agt_arg_vpc) != AGT_FBINARY_TYPE_VLE_PATH)
-    {
-        ereport(ERROR,
-            (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
             errmsg("argument 1 of age_match_vle_edge_to_edge_qual must be a VLE_Path_Container")));
-    }
 
-    /* cast argument as a VLE_Path_Container and extract graphid array */
-    vle_path = (path_container *)agt_arg_vpc;
-    array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vle_path);
+    // cast argument as a VLE_Path_Container and extract graphid array 
+    path_container *vle_path = (path_container *)agt;
+    graphid *array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vle_path);
 
-    if (types[1] == AGTYPEOID)
-    {
-        /* Get the edge id we are checking the end of the list too */
-        edge_id = AG_GET_ARG_AGTYPE_P(1);
+    graphid gid = DATUM_GET_GRAPHID(args[1]);
 
-        if (!AGT_ROOT_IS_SCALAR(edge_id))
-        {
-            ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("argument 2 of age_match_vle_edge_to_edge_qual must be an integer")));
-        }
-
-        id = get_ith_agtype_value_from_container(&edge_id->root, 0);
-
-        if (id->type != AGTV_INTEGER)
-        {
-            ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("argument 2 of age_match_vle_edge_to_edge_qual must be an integer")));
-        }
-
-        gid = id->val.int_value;
-    }
-    else if (types[1] == GRAPHIDOID)
-    {
-
-        gid = DATUM_GET_GRAPHID(args[1]);
-
-    }
-    else
-    {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("match_vle_terminal_edge() arguement 1 must be an agtype integer or a graphid")));
-    }
-
-    pos_agt = AG_GET_ARG_AGTYPE_P(2);
+    agtype *pos_agt = DATUM_GET_AGTYPE_P(args[2]);
 
     if (!AGT_ROOT_IS_SCALAR(pos_agt))
-    {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("argument 3 of age_match_vle_edge_to_edge_qual must be an integer")));
-    }
 
-    position = get_ith_agtype_value_from_container(&pos_agt->root, 0);
+    agtype_value *position = get_ith_agtype_value_from_container(&pos_agt->root, 0);
 
     if (position->type != AGTV_BOOL)
-    {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("argument 3 of age_match_vle_edge_to_edge_qual must be an integer")));
-    }
-
-    vle_is_on_left = position->val.boolean;
-
-    if (vle_is_on_left)
-    {
-        int array_size = vle_path->graphid_array_size;
-
-        /*
-         * Path is like ...[vle_edge]-()-[regular_edge]... Get the graphid of
-         * the vertex at the endof the path and check that it matches the id
-         * that was passed in the second arg. The transform logic is responsible
-         * for making that the start or end id, depending on its direction.
-         */
-        if (gid != array[array_size - 1])
-        {
-            PG_RETURN_BOOL(false);
-        }
-
-        PG_RETURN_BOOL(true);
-    }
-    else
-    {
-        /*
-         * Path is like ...[edge]-()-[vle_edge]... Get the vertex at the start
-         * of the vle edge and check against id.
-         */
-        if (gid != array[0])
-        {
-            PG_RETURN_BOOL(false);
-        }
-
-        PG_RETURN_BOOL(true);
-    }
-}
-
-/*
- * Exposed helper function to make an agtype_value AGTV_ARRAY of edges from a
- * path_container.
- */
-agtype_value *agtv_materialize_vle_edges(agtype *agt_arg_vpc)
-{
-    path_container *vpc = NULL;
-    agtype_value *agtv_array = NULL;
-
-    /* the passed argument should not be NULL */
-    Assert(agt_arg_vpc != NULL);
-
-    /*
-     * The path must be a binary container and the type of the object in the
-     * container must be an AGT_FBINARY_TYPE_VLE_PATH.
-     */
-    Assert(AGT_ROOT_IS_BINARY(agt_arg_vpc));
-    Assert(AGT_ROOT_BINARY_FLAGS(agt_arg_vpc) == AGT_FBINARY_TYPE_VLE_PATH);
-
-    /* get the container */
-    vpc = (path_container *)agt_arg_vpc;
-
-    /* it should not be null */
-    Assert(vpc != NULL);
-
-    /* build the AGTV_ARRAY of edges from the path_container */
-    agtv_array = build_edge_list(vpc);
-
-    /* convert the agtype_value to agtype and return it */
-    return agtv_array;
-
-}
-
-/* PG wrapper function for agtv_materialize_vle_edges */
-PG_FUNCTION_INFO_V1(age_materialize_vle_edges);
-
-Datum age_materialize_vle_edges(PG_FUNCTION_ARGS)
-{
-    agtype *agt_arg_vpc = NULL;
-    agtype_value *agtv_array = NULL;
-
-    /* if we have a NULL path_container, return NULL */
-    if (PG_ARGISNULL(0))
-    {
-        PG_RETURN_NULL();
-    }
-
-    /* get the path_container argument */
-    agt_arg_vpc = AG_GET_ARG_AGTYPE_P(0);
-
-    /* if NULL, return NULL */
-    if (is_agtype_null(agt_arg_vpc))
-    {
-        PG_RETURN_NULL();
-    }
-
-    agtv_array = agtv_materialize_vle_edges(agt_arg_vpc);
-
-    PG_RETURN_POINTER(agtype_value_to_agtype(agtv_array));
-}
-
-/* PG wrapper function for age_materialize_vle_path */
-PG_FUNCTION_INFO_V1(age_materialize_vle_path);
-
-Datum age_materialize_vle_path(PG_FUNCTION_ARGS)
-{
-    agtype *agt_arg_vpc = NULL;
-
-    /* if we have a NULL path_container, return NULL */
-    if (PG_ARGISNULL(0))
-    {
-        PG_RETURN_NULL();
-    }
-
-    /* get the path_container argument */
-    agt_arg_vpc = AG_GET_ARG_AGTYPE_P(0);
-
-    /* if NULL, return NULL */
-    if (is_agtype_null(agt_arg_vpc))
-    {
-        PG_RETURN_NULL();
-    }
-
-    PG_RETURN_POINTER(agt_materialize_vle_path(agt_arg_vpc));
-}
-
-/*
- * PG function to take a path_container and return whether the supplied end
- * vertex (target/veid) matches against the last edge in the VLE path. The VLE
- * path is encoded in a BINARY container.
- */
-PG_FUNCTION_INFO_V1(age_match_vle_terminal_edge);
-
-Datum age_match_vle_terminal_edge(PG_FUNCTION_ARGS)
-{
-    int nargs = 0;
-    Datum *args = NULL;
-    bool *nulls = NULL;
-    Oid *types = NULL;
-    path_container *vpc = NULL;
-    agtype *agt_arg_vsid = NULL;
-    agtype *agt_arg_veid = NULL;
-    agtype *agt_arg_path = NULL;
-    agtype_value *agtv_temp = NULL;
-    graphid vsid = 0;
-    graphid veid = 0;
-    graphid *gida = NULL;
-    int gidasize = 0;
-
-    /* extract argument values */
-    nargs = extract_variadic_args(fcinfo, 0, true, &args, &types, &nulls);
-
-    if (nargs != 3)
-    {
         ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                        errmsg("age_match_terminal_edge() invalid number of arguments")));
-    }
+                 errmsg("argument 3 of age_match_vle_edge_to_edge_qual must be an integer")));
+   
+    PG_RETURN_BOOL(position->val.boolean ? gid == array[vle_path->graphid_array_size - 1] : gid != array[0]);
+}
 
-    /* the arguments cannot be NULL */
-    if (nulls[0] || nulls[1] || nulls[2])
-    {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("match_vle_terminal_edge() arguments cannot be NULL")));
-    }
+PG_FUNCTION_INFO_V1(age_materialize_vle_edges);
+Datum age_materialize_vle_edges(PG_FUNCTION_ARGS) {
+    agtype *agt = AG_GET_ARG_AGTYPE_P(0);
 
-    /* get the vpc */
-    agt_arg_path = DATUM_GET_AGTYPE_P(args[2]);
+    if (is_agtype_null(agt))
+        PG_RETURN_NULL();
 
-    /* it cannot be NULL */
-    if (is_agtype_null(agt_arg_path))
-    {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("match_vle_terminal_edge() argument 3 cannot be NULL")));
-    }
+    PG_RETURN_POINTER(agtype_value_to_agtype(build_edge_list((path_container *)agt)));
+}
 
-    /*
-     * The vpc (path) must be a binary container and the type of the object in
-     * the container must be an AGT_FBINARY_TYPE_VLE_PATH.
-     */
+// PG wrapper function for age_materialize_vle_path 
+PG_FUNCTION_INFO_V1(age_materialize_vle_path);
+Datum age_materialize_vle_path(PG_FUNCTION_ARGS) {
+    agtype *agt = AG_GET_ARG_AGTYPE_P(0);
+
+    if (is_agtype_null(agt))
+        PG_RETURN_NULL();
+
+    PG_RETURN_POINTER(agtype_value_to_agtype(agtv_materialize_vle_path(agt)));
+}
+
+PG_FUNCTION_INFO_V1(age_match_vle_terminal_edge);
+Datum age_match_vle_terminal_edge(PG_FUNCTION_ARGS) {
+    Datum *args;
+    bool *nulls;
+    Oid *types;
+    int nargs = extract_variadic_args(fcinfo, 0, true, &args, &types, &nulls);
+
+    // get the vpc 
+    agtype *agt_arg_path = DATUM_GET_AGTYPE_P(args[2]);
+
     Assert(AGT_ROOT_IS_BINARY(agt_arg_path));
     Assert(AGT_ROOT_BINARY_FLAGS(agt_arg_path) == AGT_FBINARY_TYPE_VLE_PATH);
 
-    /* get the container */
-    vpc = (path_container *)agt_arg_path;
+    // get the container 
+    path_container *vpc = (path_container *)agt_arg_path;
 
-    /* get the graphid array from the container */
-    gida = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
+    // get the graphid array from the container 
+    graphid *gida = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
 
-    /* get the gida array size */
-    gidasize = vpc->graphid_array_size;
+    // get the gida array size 
+    int gidasize = vpc->graphid_array_size;
 
-    /* verify the minimum size is 3 or 1 */
-    Assert(gidasize >= 3 || gidasize == 1);
+    // start id
+    graphid vsid; 
+    if (types[0] == AGTYPEOID) {
+        agtype *agt_arg_vsid = DATUM_GET_AGTYPE_P(args[0]);
 
-    /* get the vsid */
-    if (types[0] == AGTYPEOID)
-    {
-        agt_arg_vsid = DATUM_GET_AGTYPE_P(args[0]);
-
-        if (!is_agtype_null(agt_arg_vsid))
-        {
-
-            agtv_temp =
-               get_ith_agtype_value_from_container(&agt_arg_vsid->root, 0);
+        if (!is_agtype_null(agt_arg_vsid)) {
+            agtype_value *agtv_temp = get_ith_agtype_value_from_container(&agt_arg_vsid->root, 0);
 
             Assert(agtv_temp->type == AGTV_INTEGER);
             vsid = agtv_temp->val.int_value;
-        }
-        else
-        {
+        } else {
             ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("match_vle_terminal_edge() argument 1 must be non NULL")));
         }
     }
-    else if (types[0] == GRAPHIDOID)
-    {
+    else if (types[0] == GRAPHIDOID) {
         vsid = DATUM_GET_GRAPHID(args[0]);
-    }
-    else
-    {
+    } else {
         ereport(ERROR,
             (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
              errmsg("match_vle_terminal_edge() arguement 1 must be an agtype integer or a graphid")));
     }
 
-    /* get the veid */
-    if (types[1] == AGTYPEOID)
-    {
-        agt_arg_veid = DATUM_GET_AGTYPE_P(args[1]);
+    // end id
+    graphid veid;
+    if (types[1] == AGTYPEOID) {
+        agtype *agt_arg_veid = DATUM_GET_AGTYPE_P(args[1]);
 
-        if (!is_agtype_null(agt_arg_veid))
-        {
-            agtv_temp = get_ith_agtype_value_from_container(&agt_arg_veid->root,
-                                                            0);
+        if (!is_agtype_null(agt_arg_veid)) {
+            agtype_value *agtv_temp = get_ith_agtype_value_from_container(&agt_arg_veid->root, 0);
             Assert(agtv_temp->type == AGTV_INTEGER);
             veid = agtv_temp->val.int_value;
-        }
-        else
-        {
+        } else {
             ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("match_vle_terminal_edge() argument 2 must be non NULL")));
         }
     }
-    else if (types[1] == GRAPHIDOID)
-    {
+    else if (types[1] == GRAPHIDOID) {
         veid = DATUM_GET_GRAPHID(args[1]);
-    }
-    else
-    {
+    } else {
         ereport(ERROR,
             (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
              errmsg("match_vle_terminal_edge() arguement 2 must be an agtype integer or a graphid")));
     }
 
-    /* compare the path beginning or end points */
+    // compare the path beginning or end points 
     PG_RETURN_BOOL(gida[0] == vsid && veid == gida[gidasize - 1]);
 }
 
-/* PG helper function to build an agtype (Datum) edge for matching */
+static const agtype_value agtv_nstr = {
+    .type = AGTV_STRING,
+    .val.string = {0, NULL}
+};
+
+static const agtype_value agtv_zero = {
+    .type = AGTV_INTEGER,
+    .val.int_value = 0
+};
+
+// PG helper function to build an agtype (Datum) edge for matching 
 PG_FUNCTION_INFO_V1(age_build_vle_match_edge);
-
-Datum age_build_vle_match_edge(PG_FUNCTION_ARGS)
-{
+Datum age_build_vle_match_edge(PG_FUNCTION_ARGS) {
     agtype_in_state result;
-    agtype_value agtv_zero;
-    agtype_value agtv_nstr;
-    agtype_value *agtv_temp = NULL;
-
-    /* create an agtype_value integer 0 */
-    agtv_zero.type = AGTV_INTEGER;
-    agtv_zero.val.int_value = 0;
-
-    /* create an agtype_value null string */
-    agtv_nstr.type = AGTV_STRING;
-    agtv_nstr.val.string.len = 0;
-    agtv_nstr.val.string.val = NULL;
-
-    /* zero the state */
     memset(&result, 0, sizeof(agtype_in_state));
 
-    /* start the object */
-    result.res = push_agtype_value(&result.parse_state, WAGT_BEGIN_OBJECT,
-                                   NULL);
-    /* create dummy graph id */
-    result.res = push_agtype_value(&result.parse_state, WAGT_KEY,
-                                   string_to_agtype_value("id"));
+    // start object 
+    result.res = push_agtype_value(&result.parse_state, WAGT_BEGIN_OBJECT, NULL);
+
+    // id 
+    result.res = push_agtype_value(&result.parse_state, WAGT_KEY, string_to_agtype_value("id"));
     result.res = push_agtype_value(&result.parse_state, WAGT_VALUE, &agtv_zero);
-    /* process the label */
-    result.res = push_agtype_value(&result.parse_state, WAGT_KEY,
-                                   string_to_agtype_value("label"));
-    if (!PG_ARGISNULL(0))
-    {
-        agtv_temp = get_agtype_value("build_vle_match_edge",
-                                     AG_GET_ARG_AGTYPE_P(0), AGTV_STRING, true);
-        result.res = push_agtype_value(&result.parse_state, WAGT_VALUE,
-                                       agtv_temp);
+    
+    // label 
+    result.res = push_agtype_value(&result.parse_state, WAGT_KEY, string_to_agtype_value("label"));
+    if (!PG_ARGISNULL(0)) {
+        agtype_value *agtv_temp = get_agtype_value("build_vle_match_edge", AG_GET_ARG_AGTYPE_P(0), AGTV_STRING, true);
+        result.res = push_agtype_value(&result.parse_state, WAGT_VALUE, agtv_temp);
+    } else {
+        result.res = push_agtype_value(&result.parse_state, WAGT_VALUE, &agtv_nstr);
     }
-    else
-    {
-        result.res = push_agtype_value(&result.parse_state, WAGT_VALUE,
-                                       &agtv_nstr);
-    }
-    /* create dummy end_id */
-    result.res = push_agtype_value(&result.parse_state, WAGT_KEY,
-                                   string_to_agtype_value("end_id"));
+
+    // end_id 
+    result.res = push_agtype_value(&result.parse_state, WAGT_KEY, string_to_agtype_value("end_id"));
     result.res = push_agtype_value(&result.parse_state, WAGT_VALUE, &agtv_zero);
-    /* create dummy start_id */
-    result.res = push_agtype_value(&result.parse_state, WAGT_KEY,
-                                   string_to_agtype_value("start_id"));
+    // start_id 
+    result.res = push_agtype_value(&result.parse_state, WAGT_KEY, string_to_agtype_value("start_id"));
     result.res = push_agtype_value(&result.parse_state, WAGT_VALUE, &agtv_zero);
 
-    /* process the properties */
-    result.res = push_agtype_value(&result.parse_state, WAGT_KEY,
-                                   string_to_agtype_value("properties"));
-    if (!PG_ARGISNULL(1))
-    {
+    // properties 
+    result.res = push_agtype_value(&result.parse_state, WAGT_KEY, string_to_agtype_value("properties"));
+    if (!PG_ARGISNULL(1)) {
         agtype *properties = NULL;
 
         properties = AG_GET_ARG_AGTYPE_P(1);
 
         if (!AGT_ROOT_IS_OBJECT(properties))
-        {
-            ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("build_vle_match_edge(): properties argument must be an object")));
-        }
+            PG_RETURN_NULL();
 
         add_agtype((Datum)properties, false, &result, AGTYPEOID, false);
 
-    }
-    else
-    {
-        result.res = push_agtype_value(&result.parse_state, WAGT_BEGIN_OBJECT,
-                                       NULL);
-        result.res = push_agtype_value(&result.parse_state, WAGT_END_OBJECT,
-                                       NULL);
+    } else {
+        result.res = push_agtype_value(&result.parse_state, WAGT_BEGIN_OBJECT, NULL);
+        result.res = push_agtype_value(&result.parse_state, WAGT_END_OBJECT, NULL);
     }
 
     result.res = push_agtype_value(&result.parse_state, WAGT_END_OBJECT, NULL);
@@ -2375,186 +1249,72 @@ Datum age_build_vle_match_edge(PG_FUNCTION_ARGS)
  * Arguements can be a combination of agtype ints and path_containers.
  */
 PG_FUNCTION_INFO_V1(_ag_enforce_edge_uniqueness);
+Datum _ag_enforce_edge_uniqueness(PG_FUNCTION_ARGS) {
+    Datum *args;
+    bool *nulls;
+    Oid *types;
 
-Datum _ag_enforce_edge_uniqueness(PG_FUNCTION_ARGS)
-{
-    HTAB *exists_hash = NULL;
+    int nargs = extract_variadic_args(fcinfo, 0, true, &args, &types, &nulls);
+
+    // configure the hash table 
     HASHCTL exists_ctl;
-    Datum *args = NULL;
-    bool *nulls = NULL;
-    Oid *types = NULL;
-    int nargs = 0;
-    int i = 0;
-
-    /* extract our arguments */
-    nargs = extract_variadic_args(fcinfo, 0, true, &args, &types, &nulls);
-
-    /* verify the arguments */
-    for (i = 0; i < nargs; i++)
-    {
-        if (nulls[i])
-        {
-             ereport(ERROR,
-                     (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                      errmsg("_ag_enforce_edge_uniqueness argument %d must not be NULL",
-                             i)));
-        }
-        if (types[i] != AGTYPEOID &&
-            types[i] != INT8OID &&
-            types[i] != GRAPHIDOID)
-        {
-             ereport(ERROR,
-                     (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                      errmsg("_ag_enforce_edge_uniqueness argument %d must be AGTYPE, INT8, or GRAPHIDOID",
-                             i)));
-        }
-    }
-
-    /* configure the hash table */
     MemSet(&exists_ctl, 0, sizeof(exists_ctl));
     exists_ctl.keysize = sizeof(int64);
     exists_ctl.entrysize = sizeof(int64);
     exists_ctl.hash = tag_hash;
 
-    /* create exists_hash table */
-    exists_hash = hash_create(EXISTS_HTAB_NAME, EXISTS_HTAB_NAME_INITIAL_SIZE,
-                              &exists_ctl, HASH_ELEM | HASH_FUNCTION);
+    HTAB *exists_hash = hash_create(EXISTS_HTAB_NAME, EXISTS_HTAB_NAME_INITIAL_SIZE, &exists_ctl, HASH_ELEM | HASH_FUNCTION);
 
-    /* insert arguments into hash table */
-    for (i = 0; i < nargs; i++)
-    {
-        /* if it is an INT8OID or a GRAPHIDOID */
-        if (types[i] == INT8OID || types[i] == GRAPHIDOID)
-        {
-            graphid edge_id = 0;
-            bool found = false;
-            int64 *value = NULL;
+    // insert arguments into hash table 
+    for (int i = 0; i < nargs; i++) {
 
-            edge_id = DatumGetInt64(args[i]);
+        if (nulls[i])
+             ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                      errmsg("_ag_enforce_edge_uniqueness argument %d must not be NULL", i)));
 
-            /* insert the edge_id */
-            value = (int64 *)hash_search(exists_hash, (void *)&edge_id,
-                                         HASH_ENTER, &found);
+        if (types[i] == GRAPHIDOID) {
+            graphid edge_id = DatumGetInt64(args[i]);
 
-            /* if we found it, we're done, we have a duplicate */
+	    bool found;
+            int64 *value = (int64 *)hash_search(exists_hash, (void *)&edge_id, HASH_ENTER, &found);
+
+            // if we found it, we're done, we have a duplicate 
             if (found)
-            {
-                hash_destroy(exists_hash);
                 PG_RETURN_BOOL(false);
-            }
-            /* otherwise, add it to the returned bucket */
-            else
-            {
-                *value = edge_id;
-            }
+
+            *value = edge_id;
 
             continue;
         }
-        else if (types[i] == AGTYPEOID)
-        {
-            /* get the argument */
+        else if (types[i] == AGTYPEOID) {
             agtype *agt_i = DATUM_GET_AGTYPE_P(args[i]);
 
-            /* if the argument is an AGTYPE path_container */
-            if (AGT_ROOT_IS_BINARY(agt_i) &&
-                AGT_ROOT_BINARY_FLAGS(agt_i) == AGT_FBINARY_TYPE_VLE_PATH)
-            {
-                path_container *vpc = NULL;
-                graphid *graphid_array = NULL;
-                int64 graphid_array_size = 0;
-                int64 j = 0;
+            if (AGT_ROOT_IS_BINARY(agt_i) && AGT_ROOT_BINARY_FLAGS(agt_i) == AGT_FBINARY_TYPE_VLE_PATH) {
+                path_container *vpc = (path_container *)agt_i;
+                graphid *graphid_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
+                int64 graphid_array_size = vpc->graphid_array_size;
 
-                /* cast to path_container */
-                vpc = (path_container *)agt_i;
+                // insert all the edges in the vpc, into the hash table 
+                for (int j = 1; j < graphid_array_size - 1; j+=2) {
+                    graphid edge_id = graphid_array[j];
 
-                /* get the graphid array */
-                graphid_array = GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc);
+                    // insert the edge id 
+                    bool found;
+		    int64 *value = (int64 *)hash_search(exists_hash, (void *)&edge_id, HASH_ENTER, &found);
 
-                /* get the graphid array size */
-                graphid_array_size = vpc->graphid_array_size;
-
-                /* insert all the edges in the vpc, into the hash table */
-                for (j = 1; j < graphid_array_size - 1; j+=2)
-                {
-                    int64 *value = NULL;
-                    bool found = false;
-                    graphid edge_id = 0;
-
-                    /* get the edge id */
-                    edge_id = graphid_array[j];
-
-                    /* insert the edge id */
-                    value = (int64 *)hash_search(exists_hash, (void *)&edge_id,
-                                                 HASH_ENTER, &found);
-
-                    /* if we found it, we're done, we have a duplicate */
                     if (found)
-                    {
-                        hash_destroy(exists_hash);
                         PG_RETURN_BOOL(false);
-                    }
-                    /* otherwise, add it to the returned bucket */
-                    else
-                    {
-                        *value = edge_id;
-                    }
-                }
-            }
-            /* if it is a regular AGTYPE scalar */
-            else if (AGT_ROOT_IS_SCALAR(agt_i))
-            {
-                agtype_value *agtv_id = NULL;
-                int64 *value = NULL;
-                bool found = false;
-                graphid edge_id = 0;
-
-                agtv_id = get_ith_agtype_value_from_container(&agt_i->root, 0);
-
-                if (agtv_id->type != AGTV_INTEGER)
-                {
-                    ereport(ERROR,
-                            (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                             errmsg("_ag_enforce_edge_uniqueness parameter %d must resolve to an agtype integer",
-                                    i)));
-                }
-
-                edge_id = agtv_id->val.int_value;
-
-                /* insert the edge_id */
-                value = (int64 *)hash_search(exists_hash, (void *)&edge_id,
-                                             HASH_ENTER, &found);
-
-                /* if we found it, we're done, we have a duplicate */
-                if (found)
-                {
-                    hash_destroy(exists_hash);
-                    PG_RETURN_BOOL(false);
-                }
-                /* otherwise, add it to the returned bucket */
-                else
-                {
+                    
                     *value = edge_id;
+                   
                 }
-            }
-            else
-            {
+            } else {
                 ereport(ERROR,
                         (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                         errmsg("_ag_enforce_edge_uniqueness invalid parameter type %d",
-                                i)));
+                         errmsg("_ag_enforce_edge_uniqueness invalid parameter type %d", i)));
             }
-        }
-        /* it is neither a path_container, AGTYPE, INT8, or a GRAPHIDOID */
-        else
-        {
-            ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("_ag_enforce_edge_uniqueness invalid parameter type %d",
-                            i)));
         }
     }
 
-    /* if all entries were successfully inserted, we have no duplicates */
-    hash_destroy(exists_hash);
     PG_RETURN_BOOL(true);
 }

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -1579,7 +1579,7 @@ Datum _agtype_build_path(PG_FUNCTION_ARGS)
             if (AGT_ROOT_IS_BINARY(agt) &&
                 AGT_ROOT_BINARY_FLAGS(agt) == AGT_FBINARY_TYPE_VLE_PATH)
             {
-                agtype *path = agt_materialize_vle_path(agt);
+                agtype *path = agtype_value_to_agtype(agtv_materialize_vle_path(agt));
                 PG_RETURN_POINTER(path);
             }
         }

--- a/src/include/utils/age_vle.h
+++ b/src/include/utils/age_vle.h
@@ -31,19 +31,9 @@
 typedef struct path_container path_container;
 
 /*
- * Function to take an AGTV_BINARY path_container and return a path as an
- * agtype.
- */
-agtype *agt_materialize_vle_path(agtype *agt_arg_vpc);
-/*
  * Function to take a AGTV_BINARY path_container and return a path as an
  * agtype_value.
  */
 agtype_value *agtv_materialize_vle_path(agtype *agt_arg_vpc);
-/*
- * Exposed helper function to make an agtype_value AGTV_ARRAY of edges from a
- * path_container.
- */
-agtype_value *agtv_materialize_vle_edges(agtype *agt_arg_vpc);
 
 #endif


### PR DESCRIPTION
So far the caching that the VLE does has not been proven to improve performance, remove it in order to simplify the conversion from a set returning function to an execution node.