### PR TITLE
Refactor Builtin Function Names

### DIFF
--- a/postgraph--0.0.1.sql
+++ b/postgraph--0.0.1.sql
@@ -175,7 +175,7 @@ CREATE OPERATOR ?& (LEFTARG = vertex, RIGHTARG = text[], FUNCTION = vertex_exist
 --
 -- vertex functions
 --
-CREATE FUNCTION id(vertex) RETURNS graphid LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'vertex_id';
+CREATE FUNCTION id(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'vertex_id';
 CREATE FUNCTION label(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'vertex_label';
 CREATE FUNCTION properties(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'vertex_properties';
 CREATE FUNCTION age_properties(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'vertex_properties';
@@ -207,9 +207,9 @@ CREATE OPERATOR <> (FUNCTION = edge_ne, LEFTARG = edge, RIGHTARG = edge, COMMUTA
 --
 -- edge functions
 --
-CREATE FUNCTION id(edge) RETURNS graphid LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_id';
-CREATE FUNCTION start_id(edge) RETURNS graphid LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_start_id';
-CREATE FUNCTION end_id(edge) RETURNS graphid LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_end_id';
+CREATE FUNCTION id(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_id';
+CREATE FUNCTION start_id(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_start_id';
+CREATE FUNCTION end_id(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_end_id';
 CREATE FUNCTION label(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_label';
 CREATE FUNCTION properties(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_properties';
 CREATE FUNCTION age_properties(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_properties';
@@ -228,7 +228,7 @@ CREATE TYPE traversal (INPUT = traversal_in, OUTPUT = traversal_out, LIKE = json
 --
 -- traversal functions
 --
-CREATE FUNCTION age_relationships(traversal) RETURNS edge[] LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'traversal_edges';
+CREATE FUNCTION relationships(traversal) RETURNS edge[] LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'traversal_edges';
 
 
 --
@@ -451,12 +451,12 @@ CREATE CAST (gtype AS int[]) WITH FUNCTION gtype_to_int4_array(gtype);
 --
 -- XXX: Need to merge the underlying logic between this and the above functions
 --
-CREATE FUNCTION age_toboolean(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_tofloat(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_tointeger(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_tointeger';
-CREATE FUNCTION age_tostring(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_tonumeric(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_totimestamp(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
+CREATE FUNCTION toboolean (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_toboolean';
+CREATE FUNCTION tofloat (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_tofloat';
+CREATE FUNCTION tointeger(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_tointeger';
+CREATE FUNCTION tostring (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_tostring';
+CREATE FUNCTION tonumeric (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_tonumeric';
+CREATE FUNCTION totimestamp (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_totimestamp';
 
 
 --
@@ -475,7 +475,7 @@ CREATE OPERATOR @= (FUNCTION = gtype_in_operator, LEFTARG = gtype, RIGHTARG = gt
 CREATE FUNCTION gtype_string_match_starts_with(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
 CREATE FUNCTION gtype_string_match_ends_with(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
 CREATE FUNCTION gtype_string_match_contains(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_eq_tilde(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION eq_tilde (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_eq_tilde';
 
 --
 -- functions for updating clauses
@@ -496,74 +496,68 @@ CREATE FUNCTION get_cypher_keywords(OUT word text, OUT catcode "char", OUT catde
 --
 -- Scalar Functions
 --
-CREATE FUNCTION age_id(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'age_vertex_id';
-CREATE FUNCTION age_id(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'age_edge_id';
-CREATE FUNCTION age_start_id(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'age_edge_start_id';
-CREATE FUNCTION age_end_id(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'age_edge_end_id';
-CREATE FUNCTION age_head(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_last(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_startnode(gtype, edge) RETURNS vertex LANGUAGE c STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'age_edge_startnode';
-CREATE FUNCTION age_endnode(gtype, edge) RETURNS vertex LANGUAGE c STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'age_edge_endnode';
-CREATE FUNCTION age_size(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_type(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME','age_vertex_label';
-CREATE FUNCTION age_label(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME','age_vertex_label';
+CREATE FUNCTION head (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_head';
+CREATE FUNCTION last (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_last';
+CREATE FUNCTION startnode(gtype, edge) RETURNS vertex LANGUAGE c STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_startnode';
+CREATE FUNCTION endnode(gtype, edge) RETURNS vertex LANGUAGE c STABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_endnode';
+CREATE FUNCTION size (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_size';
+CREATE FUNCTION type(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME','vertex_label';
 
-CREATE FUNCTION age_type(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME','age_edge_label';
-CREATE FUNCTION age_label(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME','age_edge_label';
+CREATE FUNCTION type(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME','edge_label';
 
 --
 -- list functions
 --
-CREATE FUNCTION age_keys(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_keys(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'age_vertex_keys';
-CREATE FUNCTION age_keys(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'age_edge_keys';
+CREATE FUNCTION keys (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_keys';
+CREATE FUNCTION keys(vertex) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'vertex_keys';
+CREATE FUNCTION keys(edge) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'edge_keys';
 
-CREATE FUNCTION age_range(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_range(gtype, gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_unnest(gtype, block_types boolean = false) RETURNS SETOF gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION range (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_range';
+CREATE FUNCTION range (gtype, gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_range';
+CREATE FUNCTION unnest (gtype, block_types boolean = false) RETURNS SETOF gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_unnest';
 
 --
 -- String functions
 --
-CREATE FUNCTION age_reverse(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_toupper(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_tolower(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_ltrim(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_rtrim(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_trim(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_right(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_left(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_substring(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_substring(gtype, gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_split(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_replace(gtype, gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION reverse (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_reverse';
+CREATE FUNCTION toupper (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_toupper';
+CREATE FUNCTION tolower (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_tolower';
+CREATE FUNCTION ltrim (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_ltrim';
+CREATE FUNCTION rtrim (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_rtrim';
+CREATE FUNCTION "trim" (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_trim';
+CREATE FUNCTION right (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_right';
+CREATE FUNCTION left (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_left';
+CREATE FUNCTION "substring" (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_substring';
+CREATE FUNCTION "substring" (gtype, gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_substring';
+CREATE FUNCTION split (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_split';
+CREATE FUNCTION replace (gtype, gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_replace';
 
 --
 -- Trig functions - radian input
 --
-CREATE FUNCTION age_sin(gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_cos(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_tan(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_cot(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_asin(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_acos(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_atan(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_atan2(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_degrees(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_radians(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_round(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_round(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_ceil(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_floor(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_abs(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_sign(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_log(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_log10(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_e() RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_exp(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_sqrt(gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_pi() RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_rand() RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION sin (gtype) RETURNS gtype LANGUAGE c IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_sin';
+CREATE FUNCTION cos (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_cos';
+CREATE FUNCTION tan (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_tan';
+CREATE FUNCTION cot (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_cot';
+CREATE FUNCTION asin (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_asin';
+CREATE FUNCTION acos (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_acos';
+CREATE FUNCTION atan (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_atan';
+CREATE FUNCTION atan2 (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_atan2';
+CREATE FUNCTION degrees (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_degrees';
+CREATE FUNCTION radians (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_radians';
+CREATE FUNCTION round (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_round';
+CREATE FUNCTION round (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_round';
+CREATE FUNCTION ceil (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_ceil';
+CREATE FUNCTION floor (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_floor';
+CREATE FUNCTION abs (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_abs';
+CREATE FUNCTION sign (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_sign';
+CREATE FUNCTION log (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_log';
+CREATE FUNCTION log10 (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_log10';
+CREATE FUNCTION e () RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_e';
+CREATE FUNCTION exp (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_exp';
+CREATE FUNCTION sqrt (gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS 'MODULE_PATHNAME', 'gtype_sqrt';
+CREATE FUNCTION pi () RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_pi';
+CREATE FUNCTION rand () RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_rand';
 
 --
 -- Agreggation
@@ -572,41 +566,41 @@ CREATE FUNCTION age_rand() RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS '
 CREATE FUNCTION gtype_accum(float8[], gtype) RETURNS float8[] LANGUAGE c IMMUTABLE STRICT PARALLEL SAFE AS 'MODULE_PATHNAME';
 
 -- count
-CREATE AGGREGATE age_count(*) (stype = int8, sfunc = int8inc, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
-CREATE AGGREGATE age_count(gtype) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
-CREATE AGGREGATE age_count(vertex) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
-CREATE AGGREGATE age_count(edge) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
-CREATE AGGREGATE age_count(traversal) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
-CREATE AGGREGATE age_count(variable_edge) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
+CREATE AGGREGATE count(*) (stype = int8, sfunc = int8inc, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
+CREATE AGGREGATE count(gtype) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
+CREATE AGGREGATE count(vertex) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
+CREATE AGGREGATE count(edge) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
+CREATE AGGREGATE count(traversal) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
+CREATE AGGREGATE count(variable_edge) (stype = int8, sfunc = int8inc_any, finalfunc = int8_to_gtype, combinefunc = int8pl, finalfunc_modify = READ_ONLY, initcond = 0, parallel = SAFE);
 -- stdev
 CREATE FUNCTION gtype_stddev_samp_final(float8[]) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE AGGREGATE age_stdev(gtype) (stype = float8[], sfunc = gtype_accum, finalfunc = gtype_stddev_samp_final, combinefunc = float8_combine, finalfunc_modify = READ_ONLY, initcond = '{0,0,0}', parallel = SAFE);
+CREATE AGGREGATE stdev(gtype) (stype = float8[], sfunc = gtype_accum, finalfunc = gtype_stddev_samp_final, combinefunc = float8_combine, finalfunc_modify = READ_ONLY, initcond = '{0,0,0}', parallel = SAFE);
 -- stdevp
 CREATE FUNCTION gtype_stddev_pop_final(float8[]) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE AGGREGATE age_stdevp(gtype) (stype = float8[], sfunc = gtype_accum, finalfunc = gtype_stddev_pop_final, combinefunc = float8_combine, finalfunc_modify = READ_ONLY, initcond = '{0,0,0}', parallel = SAFE);
+CREATE AGGREGATE stdevp(gtype) (stype = float8[], sfunc = gtype_accum, finalfunc = gtype_stddev_pop_final, combinefunc = float8_combine, finalfunc_modify = READ_ONLY, initcond = '{0,0,0}', parallel = SAFE);
 -- avg
-CREATE AGGREGATE age_avg(gtype) (stype = float8[], sfunc = gtype_accum, finalfunc = float8_avg, combinefunc = float8_combine, finalfunc_modify = READ_ONLY, initcond = '{0,0,0}', parallel = SAFE);
+CREATE AGGREGATE avg(gtype) (stype = float8[], sfunc = gtype_accum, finalfunc = float8_avg, combinefunc = float8_combine, finalfunc_modify = READ_ONLY, initcond = '{0,0,0}', parallel = SAFE);
 -- sum
-CREATE FUNCTION age_gtype_sum(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE STRICT PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE AGGREGATE age_sum(gtype) (stype = gtype, sfunc = age_gtype_sum, combinefunc = age_gtype_sum, finalfunc_modify = READ_ONLY, parallel = SAFE);
+CREATE FUNCTION gtype_sum (gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE STRICT PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_gtype_sum';
+CREATE AGGREGATE sum(gtype) (stype = gtype, sfunc = gtype_sum, combinefunc = gtype_sum, finalfunc_modify = READ_ONLY, parallel = SAFE);
 -- max
 CREATE FUNCTION gtype_max_trans(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE AGGREGATE age_max(gtype) (stype = gtype, sfunc = gtype_max_trans, combinefunc = gtype_max_trans, finalfunc_modify = READ_ONLY, parallel = SAFE);
+CREATE AGGREGATE max(gtype) (stype = gtype, sfunc = gtype_max_trans, combinefunc = gtype_max_trans, finalfunc_modify = READ_ONLY, parallel = SAFE);
 -- min
 CREATE FUNCTION gtype_min_trans(gtype, gtype) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE AGGREGATE age_min(gtype) (stype = gtype, sfunc = gtype_min_trans, combinefunc = gtype_min_trans, finalfunc_modify = READ_ONLY, parallel = SAFE);
+CREATE AGGREGATE min(gtype) (stype = gtype, sfunc = gtype_min_trans, combinefunc = gtype_min_trans, finalfunc_modify = READ_ONLY, parallel = SAFE);
 -- percentileCont and percentileDisc
-CREATE FUNCTION age_percentile_aggtransfn(internal, gtype, gtype) RETURNS internal LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_percentile_cont_aggfinalfn(internal) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_percentile_disc_aggfinalfn(internal) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE AGGREGATE age_percentilecont(gtype, gtype) (stype = internal, sfunc = age_percentile_aggtransfn, finalfunc = age_percentile_cont_aggfinalfn, parallel = SAFE);
-CREATE AGGREGATE age_percentiledisc(gtype, gtype) (stype = internal, sfunc = age_percentile_aggtransfn, finalfunc = age_percentile_disc_aggfinalfn, parallel = SAFE);
+CREATE FUNCTION percentile_aggtransfn (internal, gtype, gtype) RETURNS internal LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_percentile_aggtransfn';
+CREATE FUNCTION percentile_cont_aggfinalfn (internal) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_percentile_cont_aggfinalfn';
+CREATE FUNCTION percentile_disc_aggfinalfn (internal) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_percentile_disc_aggfinalfn';
+CREATE AGGREGATE percentilecont(gtype, gtype) (stype = internal, sfunc = percentile_aggtransfn, finalfunc = percentile_cont_aggfinalfn, parallel = SAFE);
+CREATE AGGREGATE percentiledisc(gtype, gtype) (stype = internal, sfunc = percentile_aggtransfn, finalfunc = percentile_disc_aggfinalfn, parallel = SAFE);
 -- collect
-CREATE FUNCTION age_collect_aggtransfn(internal, gtype) RETURNS internal LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE FUNCTION age_collect_aggfinalfn(internal) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME';
-CREATE AGGREGATE age_collect(gtype) (stype = internal, sfunc = age_collect_aggtransfn, finalfunc = age_collect_aggfinalfn, parallel = safe);
+CREATE FUNCTION collect_aggtransfn (internal, gtype) RETURNS internal LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_collect_aggtransfn';
+CREATE FUNCTION collect_aggfinalfn (internal) RETURNS gtype LANGUAGE c IMMUTABLE PARALLEL SAFE AS 'MODULE_PATHNAME', 'gtype_collect_aggfinalfn';
+CREATE AGGREGATE collect(gtype) (stype = internal, sfunc = collect_aggtransfn, finalfunc = collect_aggfinalfn, parallel = safe);
 
-CREATE FUNCTION age_vle(IN gtype, IN vertex, IN vertex, IN gtype, IN gtype, IN gtype, IN gtype, IN gtype, OUT edges variable_edge) RETURNS SETOF variable_edge LANGUAGE C STABLE CALLED ON NULL INPUT PARALLEL UNSAFE AS 'MODULE_PATHNAME';
+CREATE FUNCTION vle (IN gtype, IN vertex, IN vertex, IN gtype, IN gtype, IN gtype, IN gtype, IN gtype, OUT edges variable_edge) RETURNS SETOF variable_edge LANGUAGE C STABLE CALLED ON NULL INPUT PARALLEL UNSAFE AS 'MODULE_PATHNAME', 'gtype_vle';
 
 CREATE FUNCTION match_vles(variable_edge, variable_edge) RETURNS boolean LANGUAGE C IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE AS 'MODULE_PATHNAME';
 CREATE OPERATOR !!= (FUNCTION = match_vles, LEFTARG = variable_edge, RIGHTARG = variable_edge);

--- a/regress/expected/cypher_merge.out
+++ b/regress/expected/cypher_merge.out
@@ -492,7 +492,7 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a gtype
  */
 --test query
 SELECT * FROM cypher('cypher_merge', $$CREATE (n) MERGE (n)-[:e]->() $$) AS (a gtype);
-ERROR:  function postgraph.age_start_id(gtype) does not exist
+ERROR:  function postgraph.start_id(gtype) does not exist
 LINE 6: SELECT * FROM cypher('cypher_merge', $$CREATE (n) MERGE (n)-...
                                               ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.

--- a/regress/expected/cypher_unwind.out
+++ b/regress/expected/cypher_unwind.out
@@ -77,7 +77,7 @@ SELECT * FROM cypher('cypher_unwind', $$
     SET a.i = 1
     RETURN a
 $$) as (i gtype);
-ERROR:  function postgraph.age_collect(vertex) does not exist
+ERROR:  function postgraph.collect(vertex) does not exist
 LINE 3:     WITH collect(n_1) as n
                  ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.

--- a/regress/expected/cypher_vle.out
+++ b/regress/expected/cypher_vle.out
@@ -63,70 +63,70 @@ SELECT * FROM start_and_end_points;
 
 SELECT edges
 FROM start_and_end_points,
-     age_vle(
+     vle(
 	'"cypher_vle"'::gtype,
 	start_vertex, end_vertex,
 	'3'::gtype,
 	'3'::gtype,
 	'-1'::gtype);
-ERROR:  function age_vle(gtype, vertex, vertex, gtype, gtype, gtype) does not exist
-LINE 3:      age_vle(
+ERROR:  function vle(gtype, vertex, vertex, gtype, gtype, gtype) does not exist
+LINE 3:      vle(
              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- Count the total paths from left (start) to right (end) -[]-> should be 400
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, NULL, NULL);
  count 
 -------
-   400
+ 400
 (1 row)
 
 -- Count the total paths from right (end) to left (start) <-[]- should be 2
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '-1'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '-1'::gtype, NULL, NULL);
  count 
 -------
-     2
+ 2
 (1 row)
 
 -- Count the total paths undirectional -[]- should be 7092
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '0'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '0'::gtype, NULL, NULL);
  count 
 -------
-  7092
+ 7092
 (1 row)
 
 -- All paths of length 3 -[]-> should be 2
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '1'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '1'::gtype, NULL, NULL);
  count 
 -------
-     2
+ 2
 (1 row)
 
 -- All paths of length 3 <-[]- should be 1
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '-1'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '-1'::gtype, NULL, NULL);
  count 
 -------
-     1
+ 1
 (1 row)
 
 -- All paths of length 3 -[]- should be 12
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '0'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '0'::gtype, NULL, NULL);
  count 
 -------
-    12
+ 12
 (1 row)
 
 -- Test edge label matching - should match 1
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, '"edge"'::gtype, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, '"edge"'::gtype, NULL);
  count 
 -------
-     1
+ 1
 (1 row)
 
 -- Test scalar property matching - should match 1
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, NULL::gtype, '{"name": "main edge"}'::gtype);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, NULL::gtype, '{"name": "main edge"}'::gtype);
  count 
 -------
-     1
+ 1
 (1 row)
 
 -- Test the VLE match integration

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -1480,15 +1480,15 @@ $$) AS r(result gtype);
 (1 row)
 
 -- should return SQL null
-SELECT age_tonumeric('null'::gtype);
- age_tonumeric 
----------------
+SELECT tonumeric('null'::gtype);
+ tonumeric 
+-----------
  
 (1 row)
 
-SELECT age_tonumeric(null);
- age_tonumeric 
----------------
+SELECT tonumeric(null);
+ tonumeric 
+-----------
  
 (1 row)
 
@@ -1763,7 +1763,7 @@ $$) AS (id gtype);
 SELECT * FROM cypher('expr', $$
     RETURN id(null)
 $$) AS (id gtype);
-ERROR:  function postgraph.age_id(gtype) does not exist
+ERROR:  function postgraph.id(gtype) does not exist
 LINE 2:     RETURN id(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1771,7 +1771,7 @@ HINT:  No function matches the given name and argument types. You might need to 
 SELECT * FROM cypher('expr', $$
     RETURN id()
 $$) AS (id gtype);
-ERROR:  function postgraph.age_id() does not exist
+ERROR:  function postgraph.id() does not exist
 LINE 2:     RETURN id()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1791,7 +1791,7 @@ $$) AS (start_id gtype);
 SELECT * FROM cypher('expr', $$
     RETURN start_id(null)
 $$) AS (start_id gtype);
-ERROR:  function postgraph.age_start_id(gtype) does not exist
+ERROR:  function postgraph.start_id(gtype) does not exist
 LINE 2:     RETURN start_id(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1799,14 +1799,14 @@ HINT:  No function matches the given name and argument types. You might need to 
 SELECT * FROM cypher('expr', $$
     MATCH (v) RETURN start_id(v)
 $$) AS (start_id gtype);
-ERROR:  function postgraph.age_start_id(vertex) does not exist
+ERROR:  function postgraph.start_id(vertex) does not exist
 LINE 2:     MATCH (v) RETURN start_id(v)
                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN start_id()
 $$) AS (start_id gtype);
-ERROR:  function postgraph.age_start_id() does not exist
+ERROR:  function postgraph.start_id() does not exist
 LINE 2:     RETURN start_id()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1821,7 +1821,7 @@ LINE 1: SELECT * FROM cypher('expr', $$
 SELECT * FROM cypher('expr', $$
     RETURN end_id(null)
 $$) AS (end_id edge);
-ERROR:  function postgraph.age_end_id(gtype) does not exist
+ERROR:  function postgraph.end_id(gtype) does not exist
 LINE 2:     RETURN end_id(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1829,14 +1829,14 @@ HINT:  No function matches the given name and argument types. You might need to 
 SELECT * FROM cypher('expr', $$
     MATCH (v) RETURN end_id(v)
 $$) AS (end_id vertex);
-ERROR:  function postgraph.age_end_id(vertex) does not exist
+ERROR:  function postgraph.end_id(vertex) does not exist
 LINE 2:     MATCH (v) RETURN end_id(v)
                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN end_id()
 $$) AS (end_id edge);
-ERROR:  function postgraph.age_end_id() does not exist
+ERROR:  function postgraph.end_id() does not exist
 LINE 2:     RETURN end_id()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1856,7 +1856,7 @@ $$) AS (id gtype, start_id gtype, startNode vertex);
 SELECT * FROM cypher('expr', $$
     RETURN startNode(null)
 $$) AS (startNode vertex);
-ERROR:  function postgraph.age_startnode(gtype, gtype) does not exist
+ERROR:  function postgraph.startnode(gtype, gtype) does not exist
 LINE 2:     RETURN startNode(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1864,14 +1864,14 @@ HINT:  No function matches the given name and argument types. You might need to 
 SELECT * FROM cypher('expr', $$
     MATCH (v) RETURN startNode(v)
 $$) AS (startNode vertex);
-ERROR:  function postgraph.age_startnode(gtype, vertex) does not exist
+ERROR:  function postgraph.startnode(gtype, vertex) does not exist
 LINE 2:     MATCH (v) RETURN startNode(v)
                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN startNode()
 $$) AS (startNode vertex);
-ERROR:  function postgraph.age_startnode() does not exist
+ERROR:  function postgraph.startnode() does not exist
 LINE 2:     RETURN startNode()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1891,7 +1891,7 @@ $$) AS (id gtype, end_id gtype, endNode vertex);
 SELECT * FROM cypher('expr', $$
     RETURN endNode(null)
 $$) AS (endNode vertex);
-ERROR:  function postgraph.age_endnode(gtype, gtype) does not exist
+ERROR:  function postgraph.endnode(gtype, gtype) does not exist
 LINE 2:     RETURN endNode(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1899,14 +1899,14 @@ HINT:  No function matches the given name and argument types. You might need to 
 SELECT * FROM cypher('expr', $$
     MATCH (v) RETURN endNode(v)
 $$) AS (endNode vertex);
-ERROR:  function postgraph.age_endnode(gtype, vertex) does not exist
+ERROR:  function postgraph.endnode(gtype, vertex) does not exist
 LINE 2:     MATCH (v) RETURN endNode(v)
                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN endNode()
 $$) AS (endNode vertex);
-ERROR:  function postgraph.age_endnode() does not exist
+ERROR:  function postgraph.endnode() does not exist
 LINE 2:     RETURN endNode()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1921,7 +1921,7 @@ LINE 1: SELECT * FROM cypher('expr', $$
 SELECT * FROM cypher('expr', $$
     RETURN type(null)
 $$) AS (type edge);
-ERROR:  function postgraph.age_type(gtype) does not exist
+ERROR:  function postgraph.type(gtype) does not exist
 LINE 2:     RETURN type(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1935,7 +1935,7 @@ LINE 1: SELECT * FROM cypher('expr', $$
 SELECT * FROM cypher('expr', $$
     RETURN type()
 $$) AS (type vertex);
-ERROR:  function postgraph.age_type() does not exist
+ERROR:  function postgraph.type() does not exist
 LINE 2:     RETURN type()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -1956,41 +1956,41 @@ LINE 1: SELECT * FROM cypher('expr', $$
 SELECT * FROM cypher('expr', $$
     RETURN label(NULL)
 $$) AS (label edge);
-ERROR:  function postgraph.age_label(gtype) does not exist
+ERROR:  function postgraph.label(gtype) does not exist
 LINE 2:     RETURN label(NULL)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT postgraph.age_label(NULL);
-ERROR:  function postgraph.age_label(unknown) is not unique
-LINE 1: SELECT postgraph.age_label(NULL);
+SELECT postgraph.label(NULL);
+ERROR:  function postgraph.label(unknown) is not unique
+LINE 1: SELECT postgraph.label(NULL);
                ^
 HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
 -- should error
 SELECT * FROM cypher('expr', $$
     MATCH p=()-[]->() RETURN label(p)
 $$) AS (label gtype);
-ERROR:  function postgraph.age_label(traversal) does not exist
+ERROR:  function postgraph.label(traversal) does not exist
 LINE 2:     MATCH p=()-[]->() RETURN label(p)
                                      ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN label(1)
 $$) AS (label gtype);
-ERROR:  function postgraph.age_label(gtype) does not exist
+ERROR:  function postgraph.label(gtype) does not exist
 LINE 2:     RETURN label(1)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     MATCH (n) RETURN label([n])
 $$) AS (label gtype);
-ERROR:  function postgraph.age_label(gtype) does not exist
+ERROR:  function postgraph.label(gtype) does not exist
 LINE 2:     MATCH (n) RETURN label([n])
                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN label({id: 0, label: 'failed', properties: {}})
 $$) AS (label gtype);
-ERROR:  function postgraph.age_label(gtype) does not exist
+ERROR:  function postgraph.label(gtype) does not exist
 LINE 2:     RETURN label({id: 0, label: 'failed', properties: {}})
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2045,7 +2045,7 @@ ERROR:  size() unsupported argument
 SELECT * FROM cypher('expr', $$
     RETURN size()
 $$) AS (size gtype);
-ERROR:  function postgraph.age_size() does not exist
+ERROR:  function postgraph.size() does not exist
 LINE 2:     RETURN size()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2091,7 +2091,7 @@ ERROR:  head() argument must resolve to a list
 SELECT * FROM cypher('expr', $$
     RETURN head()
 $$) AS (head gtype);
-ERROR:  function postgraph.age_head() does not exist
+ERROR:  function postgraph.head() does not exist
 LINE 2:     RETURN head()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2137,7 +2137,7 @@ ERROR:  last() argument must resolve to a list or null
 SELECT * FROM cypher('expr', $$
     RETURN last()
 $$) AS (last gtype);
-ERROR:  function postgraph.age_last() does not exist
+ERROR:  function postgraph.last() does not exist
 LINE 2:     RETURN last()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2170,7 +2170,7 @@ $$) AS (properties gtype);
 SELECT * FROM cypher('expr', $$
     RETURN properties(null)
 $$) AS (properties gtype);
-ERROR:  function postgraph.age_properties(gtype) does not exist
+ERROR:  function postgraph.properties(gtype) does not exist
 LINE 2:     RETURN properties(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2178,14 +2178,14 @@ HINT:  No function matches the given name and argument types. You might need to 
 SELECT * FROM cypher('expr', $$
     RETURN properties(1234)
 $$) AS (properties gtype);
-ERROR:  function postgraph.age_properties(gtype) does not exist
+ERROR:  function postgraph.properties(gtype) does not exist
 LINE 2:     RETURN properties(1234)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN properties()
 $$) AS (properties gtype);
-ERROR:  function postgraph.age_properties() does not exist
+ERROR:  function postgraph.properties() does not exist
 LINE 2:     RETURN properties()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2234,7 +2234,7 @@ $$) AS (coalesce gtype);
 SELECT * FROM cypher('expr', $$
     RETURN coalesce(null, id(null), null)
 $$) AS (coalesce gtype);
-ERROR:  function postgraph.age_id(gtype) does not exist
+ERROR:  function postgraph.id(gtype) does not exist
 LINE 2:     RETURN coalesce(null, id(null), null)
                                   ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2311,7 +2311,7 @@ ERROR:  toBoolean() unsupported argument gtype 3
 SELECT * FROM cypher('expr', $$
     RETURN toBoolean()
 $$) AS (toBoolean gtype);
-ERROR:  function postgraph.age_toboolean() does not exist
+ERROR:  function postgraph.toboolean() does not exist
 LINE 2:     RETURN toBoolean()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2377,7 +2377,7 @@ ERROR:  cannot cast gtype boolean to type float8
 SELECT * FROM cypher('expr', $$
     RETURN toFloat()
 $$) AS (toFloat gtype);
-ERROR:  function postgraph.age_tofloat() does not exist
+ERROR:  function postgraph.tofloat() does not exist
 LINE 2:     RETURN toFloat()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2439,52 +2439,52 @@ ERROR:  cannot cast gtype boolean to type int8
 SELECT * FROM cypher('expr', $$
     RETURN toInteger()
 $$) AS (toInteger gtype);
-ERROR:  function postgraph.age_tointeger() does not exist
+ERROR:  function postgraph.tointeger() does not exist
 LINE 2:     RETURN toInteger()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
 -- toString()
 --
-SELECT * FROM age_toString(gtype_in('3'));
- age_tostring 
---------------
+SELECT * FROM toString(gtype_in('3'));
+ tostring 
+----------
  "3"
 (1 row)
 
-SELECT * FROM age_toString(gtype_in('3.14'));
- age_tostring 
---------------
+SELECT * FROM toString(gtype_in('3.14'));
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(gtype_in('3.14::float'));
- age_tostring 
---------------
+SELECT * FROM toString(gtype_in('3.14::float'));
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(gtype_in('3.14::numeric'));
- age_tostring 
---------------
+SELECT * FROM toString(gtype_in('3.14::numeric'));
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(gtype_in('true'));
- age_tostring 
---------------
+SELECT * FROM toString(gtype_in('true'));
+ tostring 
+----------
  "true"
 (1 row)
 
-SELECT * FROM age_toString(gtype_in('false'));
- age_tostring 
---------------
+SELECT * FROM toString(gtype_in('false'));
+ tostring 
+----------
  "false"
 (1 row)
 
-SELECT * FROM age_toString(gtype_in('"a string"'));
- age_tostring 
---------------
+SELECT * FROM toString(gtype_in('"a string"'));
+  tostring  
+------------
  "a string"
 (1 row)
 
@@ -2495,26 +2495,26 @@ SELECT * FROM cypher('expr', $$ RETURN toString(3.14::numeric) $$) AS (results g
 (1 row)
 
 -- should return null
-SELECT * FROM age_toString(NULL);
- age_tostring 
---------------
+SELECT * FROM toString(NULL);
+ tostring 
+----------
  
 (1 row)
 
-SELECT * FROM age_toString(gtype_in(null));
- age_tostring 
---------------
+SELECT * FROM toString(gtype_in(null));
+ tostring 
+----------
  
 (1 row)
 
 -- should fail
-SELECT * FROM age_toString();
-ERROR:  function age_tostring() does not exist
-LINE 1: SELECT * FROM age_toString();
+SELECT * FROM toString();
+ERROR:  function tostring() does not exist
+LINE 1: SELECT * FROM toString();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (results gtype);
-ERROR:  function postgraph.age_tostring() does not exist
+ERROR:  function postgraph.tostring() does not exist
 LINE 1: SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (re...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2529,8 +2529,8 @@ $$) AS (results gtype);
  "this is a string"
 (1 row)
 
-SELECT * FROM age_reverse('"gnirts a si siht"'::gtype);
-    age_reverse     
+SELECT * FROM reverse('"gnirts a si siht"'::gtype);
+      reverse       
 --------------------
  "this is a string"
 (1 row)
@@ -2544,17 +2544,17 @@ $$) AS (results gtype);
  
 (1 row)
 
-SELECT * FROM age_reverse(null);
- age_reverse 
--------------
+SELECT * FROM reverse(null);
+ reverse 
+---------
  
 (1 row)
 
 -- should return error
-SELECT * FROM age_reverse([4923, 'abc', 521, NULL, 487]);
+SELECT * FROM reverse([4923, 'abc', 521, NULL, 487]);
 ERROR:  syntax error at or near "["
-LINE 1: SELECT * FROM age_reverse([4923, 'abc', 521, NULL, 487]);
-                                  ^
+LINE 1: SELECT * FROM reverse([4923, 'abc', 521, NULL, 487]);
+                              ^
 -- Should return the reversed list
 SELECT * FROM cypher('expr', $$
     RETURN reverse([4923, 'abc', 521, NULL, 487])
@@ -2632,30 +2632,30 @@ SELECT * FROM cypher('expr', $$
     RETURN reverse(true)
 $$) AS (results gtype);
 ERROR:  reverse() unsupported argument gtype 5
-SELECT * FROM age_reverse(true);
-ERROR:  function age_reverse(boolean) does not exist
-LINE 1: SELECT * FROM age_reverse(true);
+SELECT * FROM reverse(true);
+ERROR:  function reverse(boolean) does not exist
+LINE 1: SELECT * FROM reverse(true);
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN reverse(3.14)
 $$) AS (results gtype);
 ERROR:  reverse() unsupported argument gtype 4
-SELECT * FROM age_reverse(3.14);
-ERROR:  function age_reverse(numeric) does not exist
-LINE 1: SELECT * FROM age_reverse(3.14);
+SELECT * FROM reverse(3.14);
+ERROR:  function reverse(numeric) does not exist
+LINE 1: SELECT * FROM reverse(3.14);
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN reverse()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_reverse() does not exist
+ERROR:  function postgraph.reverse() does not exist
 LINE 2:     RETURN reverse()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_reverse();
-ERROR:  function age_reverse() does not exist
-LINE 1: SELECT * FROM age_reverse();
+SELECT * FROM reverse();
+ERROR:  function reverse() does not exist
+LINE 1: SELECT * FROM reverse();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -2702,15 +2702,15 @@ $$) AS (toLower gtype);
  
 (1 row)
 
-SELECT * FROM age_toupper(null);
- age_toupper 
--------------
+SELECT * FROM toupper(null);
+ toupper 
+---------
  
 (1 row)
 
-SELECT * FROM age_tolower(null);
- age_tolower 
--------------
+SELECT * FROM tolower(null);
+ tolower 
+---------
  
 (1 row)
 
@@ -2722,7 +2722,7 @@ ERROR:  toUpper() unsupported argument gtype 5
 SELECT * FROM cypher('expr', $$
     RETURN toUpper()
 $$) AS (toUpper gtype);
-ERROR:  function postgraph.age_toupper() does not exist
+ERROR:  function postgraph.toupper() does not exist
 LINE 2:     RETURN toUpper()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2733,18 +2733,18 @@ ERROR:  toLower() unsupported argument gtype 5
 SELECT * FROM cypher('expr', $$
     RETURN toLower()
 $$) AS (toLower gtype);
-ERROR:  function postgraph.age_tolower() does not exist
+ERROR:  function postgraph.tolower() does not exist
 LINE 2:     RETURN toLower()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_toupper();
-ERROR:  function age_toupper() does not exist
-LINE 1: SELECT * FROM age_toupper();
+SELECT * FROM toupper();
+ERROR:  function toupper() does not exist
+LINE 1: SELECT * FROM toupper();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_tolower();
-ERROR:  function age_tolower() does not exist
-LINE 1: SELECT * FROM age_tolower();
+SELECT * FROM tolower();
+ERROR:  function tolower() does not exist
+LINE 1: SELECT * FROM tolower();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -2774,24 +2774,23 @@ $$) AS (results gtype);
  "string"
 (1 row)
 
-SELECT * FROM age_ltrim('"  string   "'::gtype);
-  age_ltrim  
+SELECT * FROM ltrim('"  string   "'::gtype);
+    ltrim    
 -------------
  "string   "
 (1 row)
 
-SELECT * FROM age_rtrim('"  string   "'::gtype);
- age_rtrim  
+SELECT * FROM rtrim('"  string   "'::gtype);
+   rtrim    
 ------------
  "  string"
 (1 row)
 
-SELECT * FROM age_trim('"  string   "'::gtype);
- age_trim 
-----------
- "string"
-(1 row)
-
+SELECT * FROM trim('"  string   "'::gtype);
+ERROR:  function pg_catalog.btrim(gtype) does not exist
+LINE 1: SELECT * FROM trim('"  string   "'::gtype);
+                      ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN lTrim(null)
@@ -2817,21 +2816,21 @@ $$) AS (results gtype);
  
 (1 row)
 
-SELECT * FROM age_ltrim(null);
- age_ltrim 
------------
+SELECT * FROM ltrim(null);
+ ltrim 
+-------
  
 (1 row)
 
-SELECT * FROM age_rtrim(null);
- age_rtrim 
------------
+SELECT * FROM rtrim(null);
+ rtrim 
+-------
  
 (1 row)
 
-SELECT * FROM age_trim(null);
- age_trim 
-----------
+SELECT * FROM trim(null);
+ btrim 
+-------
  
 (1 row)
 
@@ -2851,39 +2850,38 @@ ERROR:  Trim() unsupported argument gtype 5
 SELECT * FROM cypher('expr', $$
     RETURN lTrim()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_ltrim() does not exist
+ERROR:  function postgraph.ltrim() does not exist
 LINE 2:     RETURN lTrim()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN rTrim()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_rtrim() does not exist
+ERROR:  function postgraph.rtrim() does not exist
 LINE 2:     RETURN rTrim()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN trim()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_trim() does not exist
+ERROR:  function postgraph.trim() does not exist
 LINE 2:     RETURN trim()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_ltrim();
-ERROR:  function age_ltrim() does not exist
-LINE 1: SELECT * FROM age_ltrim();
+SELECT * FROM ltrim();
+ERROR:  function ltrim() does not exist
+LINE 1: SELECT * FROM ltrim();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_rtrim();
-ERROR:  function age_rtrim() does not exist
-LINE 1: SELECT * FROM age_rtrim();
+SELECT * FROM rtrim();
+ERROR:  function rtrim() does not exist
+LINE 1: SELECT * FROM rtrim();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_trim();
-ERROR:  function age_trim() does not exist
-LINE 1: SELECT * FROM age_trim();
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT * FROM trim();
+ERROR:  syntax error at or near ")"
+LINE 1: SELECT * FROM trim();
+                           ^
 --
 -- left(), right(), & substring()
 -- left()
@@ -2928,18 +2926,17 @@ $$) AS (results gtype);
  
 (1 row)
 
-SELECT * FROM age_left(null, '1'::gtype);
- age_left 
-----------
+SELECT * FROM left(null, '1'::gtype);
+ left 
+------
  
 (1 row)
 
-SELECT * FROM age_left(null, null);
- age_left 
-----------
- 
-(1 row)
-
+SELECT * FROM left(null, null);
+ERROR:  function left(unknown, unknown) is not unique
+LINE 1: SELECT * FROM left(null, null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN left("123456789", null)
@@ -2960,25 +2957,24 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN left()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_left() does not exist
+ERROR:  function postgraph.left() does not exist
 LINE 2:     RETURN left()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_left('123456789', null);
- age_left 
-----------
- 
-(1 row)
-
-SELECT * FROM age_left('"123456789"'::gtype, '-1'::gtype);
-  age_left  
+SELECT * FROM left('123456789', null);
+ERROR:  function left(unknown, unknown) is not unique
+LINE 1: SELECT * FROM left('123456789', null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM left('"123456789"'::gtype, '-1'::gtype);
+    left    
 ------------
  "12345678"
 (1 row)
 
-SELECT * FROM age_left();
-ERROR:  function age_left() does not exist
-LINE 1: SELECT * FROM age_left();
+SELECT * FROM left();
+ERROR:  function left() does not exist
+LINE 1: SELECT * FROM left();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --right()
@@ -3023,18 +3019,17 @@ $$) AS (results gtype);
  
 (1 row)
 
-SELECT * FROM age_right(null, '1'::gtype);
- age_right 
------------
+SELECT * FROM right(null, '1'::gtype);
+ right 
+-------
  
 (1 row)
 
-SELECT * FROM age_right(null, null);
- age_right 
------------
- 
-(1 row)
-
+SELECT * FROM right(null, null);
+ERROR:  function right(unknown, unknown) is not unique
+LINE 1: SELECT * FROM right(null, null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN right("123456789", null)
@@ -3055,25 +3050,24 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN right()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_right() does not exist
+ERROR:  function postgraph.right() does not exist
 LINE 2:     RETURN right()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_right('123456789', null);
- age_right 
------------
- 
-(1 row)
-
-SELECT * FROM age_right('"123456789"'::gtype, '-1'::gtype);
- age_right  
+SELECT * FROM right('123456789', null);
+ERROR:  function right(unknown, unknown) is not unique
+LINE 1: SELECT * FROM right('123456789', null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM right('"123456789"'::gtype, '-1'::gtype);
+   right    
 ------------
  "23456789"
 (1 row)
 
-SELECT * FROM age_right();
-ERROR:  function age_right() does not exist
-LINE 1: SELECT * FROM age_right();
+SELECT * FROM right();
+ERROR:  function right() does not exist
+LINE 1: SELECT * FROM right();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- substring()
@@ -3150,7 +3144,7 @@ ERROR:  substring() negative values are not supported for offset or length
 SELECT * FROM cypher('expr', $$
     RETURN substring("123456789")
 $$) AS (results gtype);
-ERROR:  function postgraph.age_substring(gtype) does not exist
+ERROR:  function postgraph.substring(gtype) does not exist
 LINE 2:     RETURN substring("123456789")
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -3230,21 +3224,21 @@ $$) AS (results gtype);
  
 (1 row)
 
-SELECT * FROM age_split(null, null);
- age_split 
------------
+SELECT * FROM split(null, null);
+ split 
+-------
  
 (1 row)
 
-SELECT * FROM age_split('"a,b,c,d,e,f"'::gtype, null);
- age_split 
------------
+SELECT * FROM split('"a,b,c,d,e,f"'::gtype, null);
+ split 
+-------
  
 (1 row)
 
-SELECT * FROM age_split(null, '","'::gtype);
- age_split 
------------
+SELECT * FROM split(null, '","'::gtype);
+ split 
+-------
  
 (1 row)
 
@@ -3260,29 +3254,29 @@ ERROR:  split() unsupported argument gtype 3
 SELECT * FROM cypher('expr', $$
     RETURN split("a,b,c,d,e,f")
 $$) AS (results gtype);
-ERROR:  function postgraph.age_split(gtype) does not exist
+ERROR:  function postgraph.split(gtype) does not exist
 LINE 2:     RETURN split("a,b,c,d,e,f")
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN split()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_split() does not exist
+ERROR:  function postgraph.split() does not exist
 LINE 2:     RETURN split()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_split('123456789'::gtype, '","'::gtype);
+SELECT * FROM split('123456789'::gtype, '","'::gtype);
 ERROR:  split() unsupported argument gtype 3
-SELECT * FROM age_split('"a,b,c,d,e,f"'::gtype, '-1'::gtype);
+SELECT * FROM split('"a,b,c,d,e,f"'::gtype, '-1'::gtype);
 ERROR:  split() unsupported argument gtype 3
-SELECT * FROM age_split('"a,b,c,d,e,f"'::gtype);
-ERROR:  function age_split(gtype) does not exist
-LINE 1: SELECT * FROM age_split('"a,b,c,d,e,f"'::gtype);
+SELECT * FROM split('"a,b,c,d,e,f"'::gtype);
+ERROR:  function split(gtype) does not exist
+LINE 1: SELECT * FROM split('"a,b,c,d,e,f"'::gtype);
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_split();
-ERROR:  function age_split() does not exist
-LINE 1: SELECT * FROM age_split();
+SELECT * FROM split();
+ERROR:  function split() does not exist
+LINE 1: SELECT * FROM split();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -3381,21 +3375,21 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN replace()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_replace() does not exist
+ERROR:  function postgraph.replace() does not exist
 LINE 2:     RETURN replace()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN replace("Hello")
 $$) AS (results gtype);
-ERROR:  function postgraph.age_replace(gtype) does not exist
+ERROR:  function postgraph.replace(gtype) does not exist
 LINE 2:     RETURN replace("Hello")
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN replace("Hello", null)
 $$) AS (results gtype);
-ERROR:  function postgraph.age_replace(gtype, gtype) does not exist
+ERROR:  function postgraph.replace(gtype, gtype) does not exist
 LINE 2:     RETURN replace("Hello", null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -3475,30 +3469,26 @@ $$) AS (results gtype);
  
 (1 row)
 
-SELECT * FROM age_sin(null);
- age_sin 
----------
- 
-(1 row)
-
-SELECT * FROM age_cos(null);
- age_cos 
----------
- 
-(1 row)
-
-SELECT * FROM age_tan(null);
- age_tan 
----------
- 
-(1 row)
-
-SELECT * FROM age_cot(null);
- age_cot 
----------
- 
-(1 row)
-
+SELECT * FROM sin(null);
+ERROR:  function sin(unknown) is not unique
+LINE 1: SELECT * FROM sin(null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM cos(null);
+ERROR:  function cos(unknown) is not unique
+LINE 1: SELECT * FROM cos(null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM tan(null);
+ERROR:  function tan(unknown) is not unique
+LINE 1: SELECT * FROM tan(null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM cot(null);
+ERROR:  function cot(unknown) is not unique
+LINE 1: SELECT * FROM cot(null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN sin("0")
@@ -3519,73 +3509,73 @@ ERROR:  cot() unsupported argument gtype 1
 SELECT * FROM cypher('expr', $$
     RETURN sin()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_sin() does not exist
+ERROR:  function postgraph.sin() does not exist
 LINE 2:     RETURN sin()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN cos()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_cos() does not exist
+ERROR:  function postgraph.cos() does not exist
 LINE 2:     RETURN cos()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN tan()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_tan() does not exist
+ERROR:  function postgraph.tan() does not exist
 LINE 2:     RETURN tan()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN cot()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_cot() does not exist
+ERROR:  function postgraph.cot() does not exist
 LINE 2:     RETURN cot()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_sin('0');
- age_sin 
----------
+SELECT * FROM sin('0'::gtype);
+ sin 
+-----
  0.0
 (1 row)
 
-SELECT * FROM age_cos('0');
- age_cos 
----------
+SELECT * FROM cos('0'::gtype);
+ cos 
+-----
  1.0
 (1 row)
 
-SELECT * FROM age_tan('0');
- age_tan 
----------
+SELECT * FROM tan('0'::gtype);
+ tan 
+-----
  0.0
 (1 row)
 
-SELECT * FROM age_cot('0');
- age_cot  
+SELECT * FROM cot('0'::gtype);
+   cot    
 ----------
  Infinity
 (1 row)
 
-SELECT * FROM age_sin();
-ERROR:  function age_sin() does not exist
-LINE 1: SELECT * FROM age_sin();
+SELECT * FROM sin();
+ERROR:  function sin() does not exist
+LINE 1: SELECT * FROM sin();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_cos();
-ERROR:  function age_cos() does not exist
-LINE 1: SELECT * FROM age_cos();
+SELECT * FROM cos();
+ERROR:  function cos() does not exist
+LINE 1: SELECT * FROM cos();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_tan();
-ERROR:  function age_tan() does not exist
-LINE 1: SELECT * FROM age_tan();
+SELECT * FROM tan();
+ERROR:  function tan() does not exist
+LINE 1: SELECT * FROM tan();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_cot();
-ERROR:  function age_cot() does not exist
-LINE 1: SELECT * FROM age_cot();
+SELECT * FROM cot();
+ERROR:  function cot() does not exist
+LINE 1: SELECT * FROM cot();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -3623,30 +3613,14 @@ $$) AS (results gtype);
  3.14159265358979
 (1 row)
 
-SELECT * FROM asin(1), age_asin('1'::gtype);
-      asin       |    age_asin     
------------------+-----------------
- 1.5707963267949 | 1.5707963267949
-(1 row)
-
-SELECT * FROM acos(0), age_acos('0'::gtype);
-      acos       |    age_acos     
------------------+-----------------
- 1.5707963267949 | 1.5707963267949
-(1 row)
-
-SELECT * FROM atan(1), age_atan('1'::gtype);
-       atan        |     age_atan      
--------------------+-------------------
- 0.785398163397448 | 0.785398163397448
-(1 row)
-
-SELECT * FROM atan2(1, 1), age_atan2('1'::gtype, '1'::gtype);
-       atan2       |     age_atan2     
--------------------+-------------------
- 0.785398163397448 | 0.785398163397448
-(1 row)
-
+SELECT * FROM asin(1), asin('1'::gtype);
+ERROR:  table name "asin" specified more than once
+SELECT * FROM acos(0), acos('0'::gtype);
+ERROR:  table name "acos" specified more than once
+SELECT * FROM atan(1), atan('1'::gtype);
+ERROR:  table name "atan" specified more than once
+SELECT * FROM atan2(1, 1), atan2('1'::gtype, '1'::gtype);
+ERROR:  table name "atan2" specified more than once
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN asin(1.1)
@@ -3712,39 +3686,35 @@ $$) AS (results gtype);
  
 (1 row)
 
-SELECT * FROM age_asin(null);
- age_asin 
-----------
+SELECT * FROM asin(null);
+ERROR:  function asin(unknown) is not unique
+LINE 1: SELECT * FROM asin(null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM acos(null);
+ERROR:  function acos(unknown) is not unique
+LINE 1: SELECT * FROM acos(null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM atan(null);
+ERROR:  function atan(unknown) is not unique
+LINE 1: SELECT * FROM atan(null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM atan2(null, null);
+ERROR:  function atan2(unknown, unknown) is not unique
+LINE 1: SELECT * FROM atan2(null, null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM atan2('1'::gtype, null);
+ atan2 
+-------
  
 (1 row)
 
-SELECT * FROM age_acos(null);
- age_acos 
-----------
- 
-(1 row)
-
-SELECT * FROM age_atan(null);
- age_atan 
-----------
- 
-(1 row)
-
-SELECT * FROM age_atan2(null, null);
- age_atan2 
------------
- 
-(1 row)
-
-SELECT * FROM age_atan2('1'::gtype, null);
- age_atan2 
------------
- 
-(1 row)
-
-SELECT * FROM age_atan2(null, '1'::gtype);
- age_atan2 
------------
+SELECT * FROM atan2(null, '1'::gtype);
+ atan2 
+-------
  
 (1 row)
 
@@ -3772,83 +3742,83 @@ ERROR:  atan2() unsupported argument gtype 1
 SELECT * FROM cypher('expr', $$
     RETURN asin()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_asin() does not exist
+ERROR:  function postgraph.asin() does not exist
 LINE 2:     RETURN asin()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN acos()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_acos() does not exist
+ERROR:  function postgraph.acos() does not exist
 LINE 2:     RETURN acos()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN atan()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_atan() does not exist
+ERROR:  function postgraph.atan() does not exist
 LINE 2:     RETURN atan()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN atan2()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_atan2() does not exist
+ERROR:  function postgraph.atan2() does not exist
 LINE 2:     RETURN atan2()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN atan2(null)
 $$) AS (results gtype);
-ERROR:  function postgraph.age_atan2(gtype) does not exist
+ERROR:  function postgraph.atan2(gtype) does not exist
 LINE 2:     RETURN atan2(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_asin('0');
- age_asin 
-----------
+SELECT * FROM asin('0'::gtype);
+ asin 
+------
  0.0
 (1 row)
 
-SELECT * FROM age_acos('0');
-    age_acos     
+SELECT * FROM acos('0'::gtype);
+      acos       
 -----------------
  1.5707963267949
 (1 row)
 
-SELECT * FROM age_atan('0');
- age_atan 
-----------
+SELECT * FROM atan('0'::gtype);
+ atan 
+------
  0.0
 (1 row)
 
-SELECT * FROM age_atan2('"0"'::gtype, '1'::gtype);
+SELECT * FROM atan2('"0"'::gtype, '1'::gtype);
 ERROR:  atan2() unsupported argument gtype 1
-SELECT * FROM age_atan2('1'::gtype, '"0"'::gtype);
+SELECT * FROM atan2('1'::gtype, '"0"'::gtype);
 ERROR:  atan2() unsupported argument gtype 1
-SELECT * FROM age_asin();
-ERROR:  function age_asin() does not exist
-LINE 1: SELECT * FROM age_asin();
+SELECT * FROM asin();
+ERROR:  function asin() does not exist
+LINE 1: SELECT * FROM asin();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_acos();
-ERROR:  function age_acos() does not exist
-LINE 1: SELECT * FROM age_acos();
+SELECT * FROM acos();
+ERROR:  function acos() does not exist
+LINE 1: SELECT * FROM acos();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_atan();
-ERROR:  function age_atan() does not exist
-LINE 1: SELECT * FROM age_atan();
+SELECT * FROM atan();
+ERROR:  function atan() does not exist
+LINE 1: SELECT * FROM atan();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_atan2();
-ERROR:  function age_atan2() does not exist
-LINE 1: SELECT * FROM age_atan2();
+SELECT * FROM atan2();
+ERROR:  function atan2() does not exist
+LINE 1: SELECT * FROM atan2();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_atan2('1'::gtype);
-ERROR:  function age_atan2(gtype) does not exist
-LINE 1: SELECT * FROM age_atan2('1'::gtype);
+SELECT * FROM atan2('1'::gtype);
+ERROR:  function atan2(gtype) does not exist
+LINE 1: SELECT * FROM atan2('1'::gtype);
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -3906,14 +3876,14 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN pi(null)
 $$) AS (results gtype);
-ERROR:  function postgraph.age_pi(gtype) does not exist
+ERROR:  function postgraph.pi(gtype) does not exist
 LINE 2:     RETURN pi(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN pi(1)
 $$) AS (results gtype);
-ERROR:  function postgraph.age_pi(gtype) does not exist
+ERROR:  function postgraph.pi(gtype) does not exist
 LINE 2:     RETURN pi(1)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4005,14 +3975,14 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN radians()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_radians() does not exist
+ERROR:  function postgraph.radians() does not exist
 LINE 2:     RETURN radians()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN degrees()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_degrees() does not exist
+ERROR:  function postgraph.degrees() does not exist
 LINE 2:     RETURN degrees()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4296,35 +4266,35 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN abs()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_abs() does not exist
+ERROR:  function postgraph.abs() does not exist
 LINE 2:     RETURN abs()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN ceil()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_ceil() does not exist
+ERROR:  function postgraph.ceil() does not exist
 LINE 2:     RETURN ceil()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN floor()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_floor() does not exist
+ERROR:  function postgraph.floor() does not exist
 LINE 2:     RETURN floor()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN round()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_round() does not exist
+ERROR:  function postgraph.round() does not exist
 LINE 2:     RETURN round()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN sign()
 $$) AS (results gtype);
-ERROR:  function postgraph.age_sign() does not exist
+ERROR:  function postgraph.sign() does not exist
 LINE 2:     RETURN sign()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4428,14 +4398,14 @@ ERROR:  cannot take logarithm of a negative number
 SELECT * from cypher('expr', $$
     RETURN log()
 $$) as (result gtype);
-ERROR:  function postgraph.age_log() does not exist
+ERROR:  function postgraph.log() does not exist
 LINE 2:     RETURN log()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * from cypher('expr', $$
     RETURN log10()
 $$) as (result gtype);
-ERROR:  function postgraph.age_log10() does not exist
+ERROR:  function postgraph.log10() does not exist
 LINE 2:     RETURN log10()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4490,7 +4460,7 @@ $$) as (result gtype);
 SELECT * from cypher('expr', $$
     RETURN exp()
 $$) as (result gtype);
-ERROR:  function postgraph.age_exp() does not exist
+ERROR:  function postgraph.exp() does not exist
 LINE 2:     RETURN exp()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4542,7 +4512,7 @@ $$) as (result gtype);
 SELECT * from cypher('expr', $$
     RETURN sqrt()
 $$) as (result gtype);
-ERROR:  function postgraph.age_sqrt() does not exist
+ERROR:  function postgraph.sqrt() does not exist
 LINE 2:     RETURN sqrt()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4667,17 +4637,17 @@ SELECT * FROM cypher('UCSC', $$ RETURN count(NULL) $$) AS (count gtype);
 
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN avg() $$) AS (avg gtype);
-ERROR:  function postgraph.age_avg() does not exist
+ERROR:  function postgraph.avg() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN avg() $$) AS (avg gty...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('UCSC', $$ RETURN sum() $$) AS (sum gtype);
-ERROR:  function postgraph.age_sum() does not exist
+ERROR:  function postgraph.sum() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN sum() $$) AS (sum gty...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('UCSC', $$ RETURN count() $$) AS (count gtype);
-ERROR:  postgraph.age_count(*) must be used to call a parameterless aggregate function
+ERROR:  postgraph.count(*) must be used to call a parameterless aggregate function
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN count() $$) AS (count...
                                                ^
 --
@@ -4714,28 +4684,28 @@ AS (min gtype, max gtype, count gtype, count_star gtype);
 
 CREATE TABLE min_max_tbl (id gtype);
 insert into min_max_tbl VALUES ('16'::gtype), ('17188'::gtype), ('1000'::gtype), ('869'::gtype);
-SELECT age_min(id), age_max(id) FROM min_max_tbl;
- age_min | age_max 
----------+---------
- 16      | 17188
+SELECT min(id), max(id) FROM min_max_tbl;
+ min |  max  
+-----+-------
+ 16  | 17188
 (1 row)
 
-SELECT age_min(age_tofloat(id)), age_max(age_tofloat(id)) FROM min_max_tbl;
- age_min | age_max 
----------+---------
- 16.0    | 17188.0
+SELECT min(tofloat(id)), max(tofloat(id)) FROM min_max_tbl;
+ min  |   max   
+------+---------
+ 16.0 | 17188.0
 (1 row)
 
-SELECT age_min(age_tonumeric(id)), age_max(age_tonumeric(id)) FROM min_max_tbl;
-   age_min   |    age_max     
+SELECT min(tonumeric(id)), max(tonumeric(id)) FROM min_max_tbl;
+     min     |      max       
 -------------+----------------
  16::numeric | 17188::numeric
 (1 row)
 
-SELECT age_min(age_tostring(id)), age_max(age_tostring(id)) FROM min_max_tbl;
- age_min | age_max 
----------+---------
- "1000"  | "869"
+SELECT min(tostring(id)), max(tostring(id)) FROM min_max_tbl;
+  min   |  max  
+--------+-------
+ "1000" | "869"
 (1 row)
 
 DROP TABLE min_max_tbl;
@@ -4752,49 +4722,49 @@ SELECT * FROM cypher('UCSC', $$ RETURN max(NULL) $$) AS (max gtype);
  
 (1 row)
 
-SELECT age_min(NULL);
- age_min 
----------
+SELECT min(NULL);
+ min 
+-----
  
 (1 row)
 
-SELECT age_min(gtype_in('null'));
- age_min 
----------
+SELECT min(gtype_in('null'));
+ min 
+-----
  
 (1 row)
 
-SELECT age_max(NULL);
- age_max 
----------
+SELECT max(NULL);
+ max 
+-----
  
 (1 row)
 
-SELECT age_max(gtype_in('null'));
- age_max 
----------
+SELECT max(gtype_in('null'));
+ max 
+-----
  
 (1 row)
 
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN min() $$) AS (min gtype);
-ERROR:  function postgraph.age_min() does not exist
+ERROR:  function postgraph.min() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN min() $$) AS (min gty...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('UCSC', $$ RETURN max() $$) AS (max gtype);
-ERROR:  function postgraph.age_max() does not exist
+ERROR:  function postgraph.max() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN max() $$) AS (max gty...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT age_min();
-ERROR:  function age_min() does not exist
-LINE 1: SELECT age_min();
+SELECT min();
+ERROR:  function min() does not exist
+LINE 1: SELECT min();
                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT age_min();
-ERROR:  function age_min() does not exist
-LINE 1: SELECT age_min();
+SELECT min();
+ERROR:  function min() does not exist
+LINE 1: SELECT min();
                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -4822,12 +4792,12 @@ SELECT * FROM cypher('UCSC', $$ RETURN stDevP(NULL) $$) AS (stDevP gtype);
 
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN stDev() $$) AS (stDev gtype);
-ERROR:  function postgraph.age_stdev() does not exist
+ERROR:  function postgraph.stdev() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN stDev() $$) AS (stDev...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('UCSC', $$ RETURN stDevP() $$) AS (stDevP gtype);
-ERROR:  function postgraph.age_stdevp() does not exist
+ERROR:  function postgraph.stdevp() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN stDevP() $$) AS (stDe...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4918,7 +4888,7 @@ SELECT * FROM cypher('UCSC', $$ MATCH (u) WHERE u.name =~ "doesn't exist" RETURN
 
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN collect() $$) AS (collect gtype);
-ERROR:  function postgraph.age_collect() does not exist
+ERROR:  function postgraph.collect() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN collect() $$) AS (col...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -5385,7 +5355,7 @@ ERROR:  keys() argument must be an object
 SELECT * from cypher('keys', $$RETURN keys("string")$$) as (keys gtype);
 ERROR:  keys() argument must be an object
 SELECT * from cypher('keys', $$MATCH u=()-[]-() RETURN keys(u)$$) as (keys gtype);
-ERROR:  function postgraph.age_keys(traversal) does not exist
+ERROR:  function postgraph.keys(traversal) does not exist
 LINE 1: ...T * from cypher('keys', $$MATCH u=()-[]-() RETURN keys(u)$$)...
                                                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -5411,45 +5381,45 @@ SELECT * from cypher('list', $$CREATE p=({name:'rachael'})-[:knows]->({name:'mon
 -- nodes()
 -- XXX: Not Working
 SELECT * from cypher('list', $$MATCH p=()-[]->() RETURN nodes(p)$$) as (nodes gtype);
-ERROR:  function postgraph.age_nodes(traversal) does not exist
+ERROR:  function postgraph.nodes(traversal) does not exist
 LINE 1: ... * from cypher('list', $$MATCH p=()-[]->() RETURN nodes(p)$$...
                                                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * from cypher('list', $$MATCH p=()-[]->()-[]->() RETURN nodes(p)$$) as (nodes gtype);
-ERROR:  function postgraph.age_nodes(traversal) does not exist
+ERROR:  function postgraph.nodes(traversal) does not exist
 LINE 1: ... cypher('list', $$MATCH p=()-[]->()-[]->() RETURN nodes(p)$$...
                                                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- should return nothing
 SELECT * from cypher('list', $$MATCH p=()-[]->()-[]->()-[]->() RETURN nodes(p)$$) as (nodes gtype);
-ERROR:  function postgraph.age_nodes(traversal) does not exist
+ERROR:  function postgraph.nodes(traversal) does not exist
 LINE 1: ...('list', $$MATCH p=()-[]->()-[]->()-[]->() RETURN nodes(p)$$...
                                                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- should return SQL NULL
 SELECT * from cypher('list', $$RETURN nodes(NULL)$$) as (nodes gtype);
-ERROR:  function postgraph.age_nodes(gtype) does not exist
+ERROR:  function postgraph.nodes(gtype) does not exist
 LINE 1: SELECT * from cypher('list', $$RETURN nodes(NULL)$$) as (nod...
                                               ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- should return an error
 SELECT * from cypher('list', $$MATCH (u) RETURN nodes([1,2,3])$$) as (nodes gtype);
-ERROR:  function postgraph.age_nodes(gtype) does not exist
+ERROR:  function postgraph.nodes(gtype) does not exist
 LINE 1: SELECT * from cypher('list', $$MATCH (u) RETURN nodes([1,2,3...
                                                         ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * from cypher('list', $$MATCH (u) RETURN nodes("string")$$) as (nodes gtype);
-ERROR:  function postgraph.age_nodes(gtype) does not exist
+ERROR:  function postgraph.nodes(gtype) does not exist
 LINE 1: SELECT * from cypher('list', $$MATCH (u) RETURN nodes("strin...
                                                         ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * from cypher('list', $$MATCH (u) RETURN nodes(u)$$) as (nodes gtype);
-ERROR:  function postgraph.age_nodes(vertex) does not exist
+ERROR:  function postgraph.nodes(vertex) does not exist
 LINE 1: SELECT * from cypher('list', $$MATCH (u) RETURN nodes(u)$$) ...
                                                         ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * from cypher('list', $$MATCH (u)-[]->() RETURN nodes(u)$$) as (nodes gtype);
-ERROR:  function postgraph.age_nodes(vertex) does not exist
+ERROR:  function postgraph.nodes(vertex) does not exist
 LINE 1: ...T * from cypher('list', $$MATCH (u)-[]->() RETURN nodes(u)$$...
                                                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -5554,19 +5524,19 @@ SELECT * from cypher('list', $$CREATE (u:Cars {name: "MR2"}) RETURN u$$) as (Ver
 (1 row)
 
 SELECT * from cypher('list', $$MATCH (u) RETURN labels(u), u$$) as (Labels gtype, Vertices vertex);
-ERROR:  function postgraph.age_labels(vertex) does not exist
+ERROR:  function postgraph.labels(vertex) does not exist
 LINE 1: SELECT * from cypher('list', $$MATCH (u) RETURN labels(u), u...
                                                         ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- should return SQL NULL
 SELECT * from cypher('list', $$RETURN labels(NULL)$$) as (Labels gtype);
-ERROR:  function postgraph.age_labels(gtype) does not exist
+ERROR:  function postgraph.labels(gtype) does not exist
 LINE 1: SELECT * from cypher('list', $$RETURN labels(NULL)$$) as (La...
                                               ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- should return an error
 SELECT * from cypher('list', $$RETURN labels("string")$$) as (Labels gtype);
-ERROR:  function postgraph.age_labels(gtype) does not exist
+ERROR:  function postgraph.labels(gtype) does not exist
 LINE 1: SELECT * from cypher('list', $$RETURN labels("string")$$) as...
                                               ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.

--- a/regress/sql/cypher_vle.sql
+++ b/regress/sql/cypher_vle.sql
@@ -55,7 +55,7 @@ SELECT * FROM start_and_end_points;
 
 SELECT edges
 FROM start_and_end_points,
-     age_vle(
+     vle(
 	'"cypher_vle"'::gtype,
 	start_vertex, end_vertex,
 	'3'::gtype,
@@ -63,28 +63,28 @@ FROM start_and_end_points,
 	'-1'::gtype);
 
 -- Count the total paths from left (start) to right (end) -[]-> should be 400
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, NULL, NULL);
 
 -- Count the total paths from right (end) to left (start) <-[]- should be 2
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '-1'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '-1'::gtype, NULL, NULL);
 
 -- Count the total paths undirectional -[]- should be 7092
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '0'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '0'::gtype, NULL, NULL);
 
 -- All paths of length 3 -[]-> should be 2
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '1'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '1'::gtype, NULL, NULL);
 
 -- All paths of length 3 <-[]- should be 1
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '-1'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '-1'::gtype, NULL, NULL);
 
 -- All paths of length 3 -[]- should be 12
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '0'::gtype, NULL, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '3'::gtype, '3'::gtype, '0'::gtype, NULL, NULL);
 
 -- Test edge label matching - should match 1
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, '"edge"'::gtype, NULL);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, '"edge"'::gtype, NULL);
 
 -- Test scalar property matching - should match 1
-SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, NULL::gtype, '{"name": "main edge"}'::gtype);
+SELECT count(edges) FROM start_and_end_points, vle( '"cypher_vle"'::gtype, start_vertex, end_vertex, '1'::gtype, 'null'::gtype, '1'::gtype, NULL::gtype, '{"name": "main edge"}'::gtype);
 
 -- Test the VLE match integration
 -- Each should find 400

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -683,8 +683,8 @@ SELECT * FROM cypher('expr', $$
 RETURN ([0, {one: 1, pie: 3.1415927, e: 2.718281::numeric}, 2::numeric, null])
 $$) AS r(result gtype);
 -- should return SQL null
-SELECT age_tonumeric('null'::gtype);
-SELECT age_tonumeric(null);
+SELECT tonumeric('null'::gtype);
+SELECT tonumeric(null);
 SELECT * FROM cypher('expr', $$
 RETURN null::numeric
 $$) AS r(result gtype);
@@ -882,7 +882,7 @@ $$) AS (label edge);
 SELECT * FROM cypher('expr', $$
     RETURN label(NULL)
 $$) AS (label edge);
-SELECT postgraph.age_label(NULL);
+SELECT postgraph.label(NULL);
 -- should error
 SELECT * FROM cypher('expr', $$
     MATCH p=()-[]->() RETURN label(p)
@@ -1099,19 +1099,19 @@ $$) AS (toInteger gtype);
 --
 -- toString()
 --
-SELECT * FROM age_toString(gtype_in('3'));
-SELECT * FROM age_toString(gtype_in('3.14'));
-SELECT * FROM age_toString(gtype_in('3.14::float'));
-SELECT * FROM age_toString(gtype_in('3.14::numeric'));
-SELECT * FROM age_toString(gtype_in('true'));
-SELECT * FROM age_toString(gtype_in('false'));
-SELECT * FROM age_toString(gtype_in('"a string"'));
+SELECT * FROM toString(gtype_in('3'));
+SELECT * FROM toString(gtype_in('3.14'));
+SELECT * FROM toString(gtype_in('3.14::float'));
+SELECT * FROM toString(gtype_in('3.14::numeric'));
+SELECT * FROM toString(gtype_in('true'));
+SELECT * FROM toString(gtype_in('false'));
+SELECT * FROM toString(gtype_in('"a string"'));
 SELECT * FROM cypher('expr', $$ RETURN toString(3.14::numeric) $$) AS (results gtype);
 -- should return null
-SELECT * FROM age_toString(NULL);
-SELECT * FROM age_toString(gtype_in(null));
+SELECT * FROM toString(NULL);
+SELECT * FROM toString(gtype_in(null));
 -- should fail
-SELECT * FROM age_toString();
+SELECT * FROM toString();
 SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (results gtype);
 
 --
@@ -1120,14 +1120,14 @@ SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN reverse("gnirts a si siht")
 $$) AS (results gtype);
-SELECT * FROM age_reverse('"gnirts a si siht"'::gtype);
+SELECT * FROM reverse('"gnirts a si siht"'::gtype);
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN reverse(null)
 $$) AS (results gtype);
-SELECT * FROM age_reverse(null);
+SELECT * FROM reverse(null);
 -- should return error
-SELECT * FROM age_reverse([4923, 'abc', 521, NULL, 487]);
+SELECT * FROM reverse([4923, 'abc', 521, NULL, 487]);
 -- Should return the reversed list
 SELECT * FROM cypher('expr', $$
     RETURN reverse([4923, 'abc', 521, NULL, 487])
@@ -1161,15 +1161,15 @@ $$) as (u gtype);
 SELECT * FROM cypher('expr', $$
     RETURN reverse(true)
 $$) AS (results gtype);
-SELECT * FROM age_reverse(true);
+SELECT * FROM reverse(true);
 SELECT * FROM cypher('expr', $$
     RETURN reverse(3.14)
 $$) AS (results gtype);
-SELECT * FROM age_reverse(3.14);
+SELECT * FROM reverse(3.14);
 SELECT * FROM cypher('expr', $$
     RETURN reverse()
 $$) AS (results gtype);
-SELECT * FROM age_reverse();
+SELECT * FROM reverse();
 
 --
 -- toUpper() and toLower()
@@ -1190,8 +1190,8 @@ $$) AS (toUpper gtype);
 SELECT * FROM cypher('expr', $$
     RETURN toLower(null)
 $$) AS (toLower gtype);
-SELECT * FROM age_toupper(null);
-SELECT * FROM age_tolower(null);
+SELECT * FROM toupper(null);
+SELECT * FROM tolower(null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN toUpper(true)
@@ -1205,8 +1205,8 @@ $$) AS (toLower gtype);
 SELECT * FROM cypher('expr', $$
     RETURN toLower()
 $$) AS (toLower gtype);
-SELECT * FROM age_toupper();
-SELECT * FROM age_tolower();
+SELECT * FROM toupper();
+SELECT * FROM tolower();
 
 --
 -- lTrim(), rTrim(), trim()
@@ -1221,9 +1221,9 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN trim("  string   ")
 $$) AS (results gtype);
-SELECT * FROM age_ltrim('"  string   "'::gtype);
-SELECT * FROM age_rtrim('"  string   "'::gtype);
-SELECT * FROM age_trim('"  string   "'::gtype);
+SELECT * FROM ltrim('"  string   "'::gtype);
+SELECT * FROM rtrim('"  string   "'::gtype);
+SELECT * FROM trim('"  string   "'::gtype);
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN lTrim(null)
@@ -1234,9 +1234,9 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN trim(null)
 $$) AS (results gtype);
-SELECT * FROM age_ltrim(null);
-SELECT * FROM age_rtrim(null);
-SELECT * FROM age_trim(null);
+SELECT * FROM ltrim(null);
+SELECT * FROM rtrim(null);
+SELECT * FROM trim(null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN lTrim(true)
@@ -1257,9 +1257,9 @@ SELECT * FROM cypher('expr', $$
     RETURN trim()
 $$) AS (results gtype);
 
-SELECT * FROM age_ltrim();
-SELECT * FROM age_rtrim();
-SELECT * FROM age_trim();
+SELECT * FROM ltrim();
+SELECT * FROM rtrim();
+SELECT * FROM trim();
 
 --
 -- left(), right(), & substring()
@@ -1280,8 +1280,8 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN left(null, null)
 $$) AS (results gtype);
-SELECT * FROM age_left(null, '1'::gtype);
-SELECT * FROM age_left(null, null);
+SELECT * FROM left(null, '1'::gtype);
+SELECT * FROM left(null, null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN left("123456789", null)
@@ -1292,9 +1292,9 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN left()
 $$) AS (results gtype);
-SELECT * FROM age_left('123456789', null);
-SELECT * FROM age_left('"123456789"'::gtype, '-1'::gtype);
-SELECT * FROM age_left();
+SELECT * FROM left('123456789', null);
+SELECT * FROM left('"123456789"'::gtype, '-1'::gtype);
+SELECT * FROM left();
 --right()
 SELECT * FROM cypher('expr', $$
     RETURN right("123456789", 1)
@@ -1312,8 +1312,8 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN right(null, null)
 $$) AS (results gtype);
-SELECT * FROM age_right(null, '1'::gtype);
-SELECT * FROM age_right(null, null);
+SELECT * FROM right(null, '1'::gtype);
+SELECT * FROM right(null, null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN right("123456789", null)
@@ -1324,9 +1324,9 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN right()
 $$) AS (results gtype);
-SELECT * FROM age_right('123456789', null);
-SELECT * FROM age_right('"123456789"'::gtype, '-1'::gtype);
-SELECT * FROM age_right();
+SELECT * FROM right('123456789', null);
+SELECT * FROM right('"123456789"'::gtype, '-1'::gtype);
+SELECT * FROM right();
 -- substring()
 SELECT * FROM cypher('expr', $$
     RETURN substring("0123456789", 0, 1)
@@ -1395,9 +1395,9 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN split(null, ",")
 $$) AS (results gtype);
-SELECT * FROM age_split(null, null);
-SELECT * FROM age_split('"a,b,c,d,e,f"'::gtype, null);
-SELECT * FROM age_split(null, '","'::gtype);
+SELECT * FROM split(null, null);
+SELECT * FROM split('"a,b,c,d,e,f"'::gtype, null);
+SELECT * FROM split(null, '","'::gtype);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN split(123456789, ",")
@@ -1411,10 +1411,10 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN split()
 $$) AS (results gtype);
-SELECT * FROM age_split('123456789'::gtype, '","'::gtype);
-SELECT * FROM age_split('"a,b,c,d,e,f"'::gtype, '-1'::gtype);
-SELECT * FROM age_split('"a,b,c,d,e,f"'::gtype);
-SELECT * FROM age_split();
+SELECT * FROM split('123456789'::gtype, '","'::gtype);
+SELECT * FROM split('"a,b,c,d,e,f"'::gtype, '-1'::gtype);
+SELECT * FROM split('"a,b,c,d,e,f"'::gtype);
+SELECT * FROM split();
 
 --
 -- replace()
@@ -1498,10 +1498,10 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN cot(null)
 $$) AS (results gtype);
-SELECT * FROM age_sin(null);
-SELECT * FROM age_cos(null);
-SELECT * FROM age_tan(null);
-SELECT * FROM age_cot(null);
+SELECT * FROM sin(null);
+SELECT * FROM cos(null);
+SELECT * FROM tan(null);
+SELECT * FROM cot(null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN sin("0")
@@ -1527,14 +1527,14 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN cot()
 $$) AS (results gtype);
-SELECT * FROM age_sin('0');
-SELECT * FROM age_cos('0');
-SELECT * FROM age_tan('0');
-SELECT * FROM age_cot('0');
-SELECT * FROM age_sin();
-SELECT * FROM age_cos();
-SELECT * FROM age_tan();
-SELECT * FROM age_cot();
+SELECT * FROM sin('0'::gtype);
+SELECT * FROM cos('0'::gtype);
+SELECT * FROM tan('0'::gtype);
+SELECT * FROM cot('0'::gtype);
+SELECT * FROM sin();
+SELECT * FROM cos();
+SELECT * FROM tan();
+SELECT * FROM cot();
 
 --
 -- Arc functions: asin, acos, atan, & atan2
@@ -1551,10 +1551,10 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN atan2(1, 1)*4
 $$) AS (results gtype);
-SELECT * FROM asin(1), age_asin('1'::gtype);
-SELECT * FROM acos(0), age_acos('0'::gtype);
-SELECT * FROM atan(1), age_atan('1'::gtype);
-SELECT * FROM atan2(1, 1), age_atan2('1'::gtype, '1'::gtype);
+SELECT * FROM asin(1), asin('1'::gtype);
+SELECT * FROM acos(0), acos('0'::gtype);
+SELECT * FROM atan(1), atan('1'::gtype);
+SELECT * FROM atan2(1, 1), atan2('1'::gtype, '1'::gtype);
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN asin(1.1)
@@ -1586,12 +1586,12 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN atan2(1, null)
 $$) AS (results gtype);
-SELECT * FROM age_asin(null);
-SELECT * FROM age_acos(null);
-SELECT * FROM age_atan(null);
-SELECT * FROM age_atan2(null, null);
-SELECT * FROM age_atan2('1'::gtype, null);
-SELECT * FROM age_atan2(null, '1'::gtype);
+SELECT * FROM asin(null);
+SELECT * FROM acos(null);
+SELECT * FROM atan(null);
+SELECT * FROM atan2(null, null);
+SELECT * FROM atan2('1'::gtype, null);
+SELECT * FROM atan2(null, '1'::gtype);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN asin("0")
@@ -1623,16 +1623,16 @@ $$) AS (results gtype);
 SELECT * FROM cypher('expr', $$
     RETURN atan2(null)
 $$) AS (results gtype);
-SELECT * FROM age_asin('0');
-SELECT * FROM age_acos('0');
-SELECT * FROM age_atan('0');
-SELECT * FROM age_atan2('"0"'::gtype, '1'::gtype);
-SELECT * FROM age_atan2('1'::gtype, '"0"'::gtype);
-SELECT * FROM age_asin();
-SELECT * FROM age_acos();
-SELECT * FROM age_atan();
-SELECT * FROM age_atan2();
-SELECT * FROM age_atan2('1'::gtype);
+SELECT * FROM asin('0'::gtype);
+SELECT * FROM acos('0'::gtype);
+SELECT * FROM atan('0'::gtype);
+SELECT * FROM atan2('"0"'::gtype, '1'::gtype);
+SELECT * FROM atan2('1'::gtype, '"0"'::gtype);
+SELECT * FROM asin();
+SELECT * FROM acos();
+SELECT * FROM atan();
+SELECT * FROM atan2();
+SELECT * FROM atan2('1'::gtype);
 
 --
 -- pi
@@ -2001,24 +2001,24 @@ AS (min gtype, max gtype, count gtype, count_star gtype);
 CREATE TABLE min_max_tbl (id gtype);
 insert into min_max_tbl VALUES ('16'::gtype), ('17188'::gtype), ('1000'::gtype), ('869'::gtype);
 
-SELECT age_min(id), age_max(id) FROM min_max_tbl;
-SELECT age_min(age_tofloat(id)), age_max(age_tofloat(id)) FROM min_max_tbl;
-SELECT age_min(age_tonumeric(id)), age_max(age_tonumeric(id)) FROM min_max_tbl;
-SELECT age_min(age_tostring(id)), age_max(age_tostring(id)) FROM min_max_tbl;
+SELECT min(id), max(id) FROM min_max_tbl;
+SELECT min(tofloat(id)), max(tofloat(id)) FROM min_max_tbl;
+SELECT min(tonumeric(id)), max(tonumeric(id)) FROM min_max_tbl;
+SELECT min(tostring(id)), max(tostring(id)) FROM min_max_tbl;
 
 DROP TABLE min_max_tbl;
 -- should return null
 SELECT * FROM cypher('UCSC', $$ RETURN min(NULL) $$) AS (min gtype);
 SELECT * FROM cypher('UCSC', $$ RETURN max(NULL) $$) AS (max gtype);
-SELECT age_min(NULL);
-SELECT age_min(gtype_in('null'));
-SELECT age_max(NULL);
-SELECT age_max(gtype_in('null'));
+SELECT min(NULL);
+SELECT min(gtype_in('null'));
+SELECT max(NULL);
+SELECT max(gtype_in('null'));
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN min() $$) AS (min gtype);
 SELECT * FROM cypher('UCSC', $$ RETURN max() $$) AS (max gtype);
-SELECT age_min();
-SELECT age_min();
+SELECT min();
+SELECT min();
 --
 -- aggregate functions stDev() & stDevP()
 --

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -808,7 +808,7 @@ static Query *transform_cypher_unwind(cypher_parsestate *cpstate, cypher_clause 
 
     expr = transform_cypher_expr(cpstate, self->target->val, EXPR_KIND_SELECT_TARGET);
 
-    unwind = makeFuncCall(list_make1(makeString("age_unnest")), NIL, COERCE_SQL_SYNTAX, -1);
+    unwind = makeFuncCall(list_make1(makeString("unnest")), NIL, COERCE_SQL_SYNTAX, -1);
 
 
     old_expr_kind = pstate->p_expr_kind;

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -631,13 +631,13 @@ transform_cypher_typecast(cypher_parsestate *cpstate, cypher_typecast *ctypecast
 
     /* append the name of the requested typecast function */
     if (pg_strcasecmp(ctypecast->typecast, "numeric") == 0)
-        fname = lappend(fname, makeString("age_tonumeric"));
+        fname = lappend(fname, makeString("tonumeric"));
     else if (pg_strcasecmp(ctypecast->typecast, "float") == 0)
-        fname = lappend(fname, makeString("age_tofloat"));
+        fname = lappend(fname, makeString("tofloat"));
     else if (pg_strcasecmp(ctypecast->typecast, "int") == 0 || pg_strcasecmp(ctypecast->typecast, "integer") == 0)
-        fname = lappend(fname, makeString("age_tointeger"));
+        fname = lappend(fname, makeString("tointeger"));
     else if (pg_strcasecmp(ctypecast->typecast, "timestamp") == 0)
-        fname = lappend(fname, makeString("age_totimestamp"));
+        fname = lappend(fname, makeString("totimestamp"));
     else
         ereport(ERROR, (errmsg_internal("typecast \'%s\' not supported", ctypecast->typecast)));
 
@@ -651,11 +651,11 @@ static List *
 make_qualified_function_name(cypher_parsestate *cpstate, List *lst, List *targs) {
     char *name = ((Value*)linitial(lst))->val.str;
     int pnlen = strlen(name);
-    char *ag_name = palloc(pnlen + 5);
+    char *ag_name = palloc(pnlen + 1);
     int i;
         
-    // catalog functions are prefixed with age_
-    strncpy(ag_name, "age_", 4);
+//    // catalog functions are prefixed with age_
+  //  strncpy(ag_name, "age_", 4);
         
     /*
      * change all functions to lower case, this is mostly uncessary, but some
@@ -664,16 +664,16 @@ make_qualified_function_name(cypher_parsestate *cpstate, List *lst, List *targs)
      * easier.
      */ 
     for (i = 0; i < pnlen; i++)
-        ag_name[i + 4] = tolower(name[i]);
+        ag_name[i] = tolower(name[i]);
         
     // Add NULL at the end
-    ag_name[i + 4] = '\0';
+    ag_name[i] = '\0';
 
     // add the catalog schema and create list        
     List *fname = list_make2(makeString(CATALOG_SCHEMA), makeString(ag_name));
 
     // Some functions need the graph name passed to them in order to work
-    if (strcmp("startNode", name) == 0 || strcmp("endNode", name) == 0 || strcmp("vle", name) == 0 || strcmp("vertex_stats", name) == 0) {
+    if (strcmp("startnode", ag_name) == 0 || strcmp("endnode", ag_name) == 0 || strcmp("vle", ag_name) == 0 || strcmp("vertex_stats", ag_name) == 0) {
         char *graph_name = cpstate->graph_name;
         Datum d = string_to_gtype(graph_name);
         Const *c = makeConst(GTYPEOID, -1, InvalidOid, -1, d, false, false);

--- a/src/backend/utils/adt/edge.c
+++ b/src/backend/utils/adt/edge.c
@@ -227,6 +227,7 @@ edge_ne(PG_FUNCTION_ARGS) {
 /*
  * Functions
  */
+/*
 PG_FUNCTION_INFO_V1(edge_id);
 Datum
 edge_id(PG_FUNCTION_ARGS) {
@@ -234,10 +235,10 @@ edge_id(PG_FUNCTION_ARGS) {
 
     AG_RETURN_GRAPHID((graphid)e->children[0]);
 }
-
-PG_FUNCTION_INFO_V1(age_edge_id);
+i*/
+PG_FUNCTION_INFO_V1(edge_id);
 Datum
-age_edge_id(PG_FUNCTION_ARGS) {
+edge_id(PG_FUNCTION_ARGS) {
     edge *v = AG_GET_ARG_EDGE(0);
 
     gtype_value gtv = { .type = AGTV_INTEGER, .val = {.int_value = *((int64 *)(&v->children[0])) } };
@@ -245,9 +246,9 @@ age_edge_id(PG_FUNCTION_ARGS) {
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&gtv));
 }
 
-PG_FUNCTION_INFO_V1(age_edge_start_id);
+PG_FUNCTION_INFO_V1(edge_start_id);
 Datum
-age_edge_start_id(PG_FUNCTION_ARGS) {
+edge_start_id(PG_FUNCTION_ARGS) {
     edge *v = AG_GET_ARG_EDGE(0);
 
     gtype_value gtv = { .type = AGTV_INTEGER, .val = {.int_value = *((int64 *)(&v->children[2])) } };
@@ -255,9 +256,9 @@ age_edge_start_id(PG_FUNCTION_ARGS) {
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&gtv));
 }
 
-PG_FUNCTION_INFO_V1(age_edge_end_id);
+PG_FUNCTION_INFO_V1(edge_end_id);
 Datum
-age_edge_end_id(PG_FUNCTION_ARGS) {
+edge_end_id(PG_FUNCTION_ARGS) {
     edge *v = AG_GET_ARG_EDGE(0);
 
     gtype_value gtv = { .type = AGTV_INTEGER, .val = {.int_value = *((int64 *)(&v->children[4])) } };
@@ -265,9 +266,9 @@ age_edge_end_id(PG_FUNCTION_ARGS) {
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&gtv));
 }
 
-PG_FUNCTION_INFO_V1(age_edge_label);
+PG_FUNCTION_INFO_V1(edge_label);
 Datum
-age_edge_label(PG_FUNCTION_ARGS) {
+edge_label(PG_FUNCTION_ARGS) {
     edge *v = AG_GET_ARG_EDGE(0);
 
     gtype_value gtv = {
@@ -278,7 +279,7 @@ age_edge_label(PG_FUNCTION_ARGS) {
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&gtv));
 }
 
-
+/*
 PG_FUNCTION_INFO_V1(edge_start_id);
 Datum
 edge_start_id(PG_FUNCTION_ARGS) {
@@ -307,7 +308,7 @@ edge_label(PG_FUNCTION_ARGS) {
 
     PG_RETURN_DATUM(d);
 }
-
+*/
 PG_FUNCTION_INFO_V1(edge_properties);
 Datum
 edge_properties(PG_FUNCTION_ARGS) {

--- a/src/backend/utils/adt/gtype.c
+++ b/src/backend/utils/adt/gtype.c
@@ -2192,8 +2192,8 @@ static Datum get_vertex_1(const char *graph, const char *vertex_label, int64 gra
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_edge_startnode);
-Datum age_edge_startnode(PG_FUNCTION_ARGS) {
+PG_FUNCTION_INFO_V1(edge_startnode);
+Datum edge_startnode(PG_FUNCTION_ARGS) {
     gtype *agt_arg = NULL;
     gtype_value *agtv_object = NULL;
     gtype_value *agtv_value = NULL;
@@ -2218,8 +2218,8 @@ Datum age_edge_startnode(PG_FUNCTION_ARGS) {
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_edge_endnode);
-Datum age_edge_endnode(PG_FUNCTION_ARGS) {
+PG_FUNCTION_INFO_V1(edge_endnode);
+Datum edge_endnode(PG_FUNCTION_ARGS) {
     gtype *agt_arg = NULL;
     gtype_value *agtv_object = NULL;
     gtype_value *agtv_value = NULL;
@@ -2244,9 +2244,9 @@ Datum age_edge_endnode(PG_FUNCTION_ARGS) {
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_head);
+PG_FUNCTION_INFO_V1(gtype_head);
 
-Datum age_head(PG_FUNCTION_ARGS)
+Datum gtype_head(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
@@ -2264,9 +2264,9 @@ Datum age_head(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_last);
+PG_FUNCTION_INFO_V1(gtype_last);
 
-Datum age_last(PG_FUNCTION_ARGS)
+Datum gtype_last(PG_FUNCTION_ARGS)
 {
     gtype *agt_arg = NULL;
     gtype_value *agtv_result = NULL;
@@ -2298,9 +2298,9 @@ Datum age_last(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_toboolean);
+PG_FUNCTION_INFO_V1(gtype_toboolean);
 Datum
-age_toboolean(PG_FUNCTION_ARGS) {
+gtype_toboolean(PG_FUNCTION_ARGS) {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
     if (!AGT_ROOT_IS_SCALAR(agt))
@@ -2334,8 +2334,8 @@ age_toboolean(PG_FUNCTION_ARGS) {
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_size);
-Datum age_size(PG_FUNCTION_ARGS) {
+PG_FUNCTION_INFO_V1(gtype_size);
+Datum gtype_size(PG_FUNCTION_ARGS) {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     int64 result;
 
@@ -2425,9 +2425,9 @@ static gtype_iterator *get_next_list_element(gtype_iterator *it,
     return it;
 }
 
-PG_FUNCTION_INFO_V1(age_reverse);
+PG_FUNCTION_INFO_V1(gtype_reverse);
 
-Datum age_reverse(PG_FUNCTION_ARGS)
+Datum gtype_reverse(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -2537,9 +2537,9 @@ Datum age_reverse(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_toupper);
+PG_FUNCTION_INFO_V1(gtype_toupper);
 
-Datum age_toupper(PG_FUNCTION_ARGS)
+Datum gtype_toupper(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
@@ -2571,9 +2571,9 @@ Datum age_toupper(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_tolower);
+PG_FUNCTION_INFO_V1(gtype_tolower);
 
-Datum age_tolower(PG_FUNCTION_ARGS)
+Datum gtype_tolower(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
@@ -2605,9 +2605,9 @@ Datum age_tolower(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_rtrim);
+PG_FUNCTION_INFO_V1(gtype_rtrim);
 
-Datum age_rtrim(PG_FUNCTION_ARGS)
+Datum gtype_rtrim(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
@@ -2634,9 +2634,9 @@ Datum age_rtrim(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_ltrim);
+PG_FUNCTION_INFO_V1(gtype_ltrim);
 
-Datum age_ltrim(PG_FUNCTION_ARGS)
+Datum gtype_ltrim(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
@@ -2663,9 +2663,9 @@ Datum age_ltrim(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_trim);
+PG_FUNCTION_INFO_V1(gtype_trim);
 
-Datum age_trim(PG_FUNCTION_ARGS)
+Datum gtype_trim(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
@@ -2692,9 +2692,9 @@ Datum age_trim(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_right);
+PG_FUNCTION_INFO_V1(gtype_right);
 
-Datum age_right(PG_FUNCTION_ARGS)
+Datum gtype_right(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
@@ -2734,9 +2734,9 @@ Datum age_right(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_left);
+PG_FUNCTION_INFO_V1(gtype_left);
 
-Datum age_left(PG_FUNCTION_ARGS)
+Datum gtype_left(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
@@ -2776,9 +2776,9 @@ Datum age_left(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_substring);
+PG_FUNCTION_INFO_V1(gtype_substring);
 
-Datum age_substring(PG_FUNCTION_ARGS)
+Datum gtype_substring(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -2945,9 +2945,9 @@ Datum age_substring(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_split);
+PG_FUNCTION_INFO_V1(gtype_split);
 
-Datum age_split(PG_FUNCTION_ARGS)
+Datum gtype_split(PG_FUNCTION_ARGS)
 {
     text *text_string;
     text *text_delimiter;
@@ -2992,9 +2992,9 @@ Datum age_split(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(result.res));
 }
 
-PG_FUNCTION_INFO_V1(age_replace);
+PG_FUNCTION_INFO_V1(gtype_replace);
 
-Datum age_replace(PG_FUNCTION_ARGS)
+Datum gtype_replace(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -3266,9 +3266,9 @@ static Numeric get_numeric_compatible_arg(Datum arg, Oid type, char *funcname,
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_sin);
+PG_FUNCTION_INFO_V1(gtype_sin);
 
-Datum age_sin(PG_FUNCTION_ARGS)
+Datum gtype_sin(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3287,9 +3287,9 @@ Datum age_sin(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_cos);
+PG_FUNCTION_INFO_V1(gtype_cos);
 
-Datum age_cos(PG_FUNCTION_ARGS)
+Datum gtype_cos(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3308,9 +3308,9 @@ Datum age_cos(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_tan);
+PG_FUNCTION_INFO_V1(gtype_tan);
 
-Datum age_tan(PG_FUNCTION_ARGS)
+Datum gtype_tan(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3329,9 +3329,9 @@ Datum age_tan(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_cot);
+PG_FUNCTION_INFO_V1(gtype_cot);
 
-Datum age_cot(PG_FUNCTION_ARGS)
+Datum gtype_cot(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3350,9 +3350,9 @@ Datum age_cot(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_asin);
+PG_FUNCTION_INFO_V1(gtype_asin);
 
-Datum age_asin(PG_FUNCTION_ARGS)
+Datum gtype_asin(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3371,9 +3371,9 @@ Datum age_asin(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_acos);
+PG_FUNCTION_INFO_V1(gtype_acos);
 
-Datum age_acos(PG_FUNCTION_ARGS)
+Datum gtype_acos(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3392,9 +3392,9 @@ Datum age_acos(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_atan);
+PG_FUNCTION_INFO_V1(gtype_atan);
 
-Datum age_atan(PG_FUNCTION_ARGS)
+Datum gtype_atan(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3413,9 +3413,9 @@ Datum age_atan(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_atan2);
+PG_FUNCTION_INFO_V1(gtype_atan2);
 
-Datum age_atan2(PG_FUNCTION_ARGS)
+Datum gtype_atan2(PG_FUNCTION_ARGS)
 {
     gtype *x_agt = AG_GET_ARG_GTYPE_P(0);
     gtype *y_agt = AG_GET_ARG_GTYPE_P(1);
@@ -3444,9 +3444,9 @@ Datum age_atan2(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_degrees);
+PG_FUNCTION_INFO_V1(gtype_degrees);
 
-Datum age_degrees(PG_FUNCTION_ARGS)
+Datum gtype_degrees(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3465,9 +3465,9 @@ Datum age_degrees(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_radians);
+PG_FUNCTION_INFO_V1(gtype_radians);
 
-Datum age_radians(PG_FUNCTION_ARGS)
+Datum gtype_radians(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     gtype_value agtv_result;
@@ -3486,9 +3486,9 @@ Datum age_radians(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_round);
+PG_FUNCTION_INFO_V1(gtype_round);
 
-Datum age_round(PG_FUNCTION_ARGS)
+Datum gtype_round(PG_FUNCTION_ARGS)
 {
     Datum *args = NULL;
     bool *nulls = NULL;
@@ -3562,9 +3562,9 @@ Datum age_round(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_ceil);
+PG_FUNCTION_INFO_V1(gtype_ceil);
 
-Datum age_ceil(PG_FUNCTION_ARGS)
+Datum gtype_ceil(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     bool is_null = true;
@@ -3591,9 +3591,9 @@ Datum age_ceil(PG_FUNCTION_ARGS)
     }
 }
 
-PG_FUNCTION_INFO_V1(age_floor);
+PG_FUNCTION_INFO_V1(gtype_floor);
 
-Datum age_floor(PG_FUNCTION_ARGS)
+Datum gtype_floor(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     bool is_null = true;
@@ -3620,9 +3620,9 @@ Datum age_floor(PG_FUNCTION_ARGS)
     }
 }
 
-PG_FUNCTION_INFO_V1(age_abs);
+PG_FUNCTION_INFO_V1(gtype_abs);
 
-Datum age_abs(PG_FUNCTION_ARGS)
+Datum gtype_abs(PG_FUNCTION_ARGS)
 {
     gtype_value agtv_result;
     bool is_null;
@@ -3662,8 +3662,8 @@ Datum age_abs(PG_FUNCTION_ARGS)
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_sign);
-Datum age_sign(PG_FUNCTION_ARGS) {
+PG_FUNCTION_INFO_V1(gtype_sign);
+Datum gtype_sign(PG_FUNCTION_ARGS) {
     int nargs;
     Datum *args;
     bool *nulls;
@@ -3708,8 +3708,8 @@ Datum age_sign(PG_FUNCTION_ARGS) {
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_log);
-Datum age_log(PG_FUNCTION_ARGS) {
+PG_FUNCTION_INFO_V1(gtype_log);
+Datum gtype_log(PG_FUNCTION_ARGS) {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     bool is_null = true;
 
@@ -3735,8 +3735,8 @@ Datum age_log(PG_FUNCTION_ARGS) {
     }
 }
 
-PG_FUNCTION_INFO_V1(age_log10);
-Datum age_log10(PG_FUNCTION_ARGS) {
+PG_FUNCTION_INFO_V1(gtype_log10);
+Datum gtype_log10(PG_FUNCTION_ARGS) {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     bool is_null = true;
 
@@ -3762,9 +3762,9 @@ Datum age_log10(PG_FUNCTION_ARGS) {
     }
 }
 
-PG_FUNCTION_INFO_V1(age_e);
+PG_FUNCTION_INFO_V1(gtype_e);
 
-Datum age_e(PG_FUNCTION_ARGS)
+Datum gtype_e(PG_FUNCTION_ARGS)
 {
     gtype_value agtv_result = {
         .type = AGTV_FLOAT,
@@ -3774,9 +3774,9 @@ Datum age_e(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_pi);
+PG_FUNCTION_INFO_V1(gtype_pi);
     
-Datum age_pi(PG_FUNCTION_ARGS)
+Datum gtype_pi(PG_FUNCTION_ARGS)
 {   
     gtype_value agtv_result = {
         .type = AGTV_FLOAT,
@@ -3786,9 +3786,9 @@ Datum age_pi(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }   
 
-PG_FUNCTION_INFO_V1(age_rand);
+PG_FUNCTION_INFO_V1(gtype_rand);
 
-Datum age_rand(PG_FUNCTION_ARGS)
+Datum gtype_rand(PG_FUNCTION_ARGS)
 {
     gtype_value agtv_result = {
         .type = AGTV_FLOAT,
@@ -3798,9 +3798,9 @@ Datum age_rand(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_exp);
+PG_FUNCTION_INFO_V1(gtype_exp);
 
-Datum age_exp(PG_FUNCTION_ARGS)
+Datum gtype_exp(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     bool is_null = true;
@@ -3827,9 +3827,9 @@ Datum age_exp(PG_FUNCTION_ARGS)
     }
 }
 
-PG_FUNCTION_INFO_V1(age_sqrt);
+PG_FUNCTION_INFO_V1(gtype_sqrt);
 
-Datum age_sqrt(PG_FUNCTION_ARGS)
+Datum gtype_sqrt(PG_FUNCTION_ARGS)
 {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
     bool is_null = true;
@@ -4109,9 +4109,9 @@ gtype *get_one_gtype_from_variadic_args(FunctionCallInfo fcinfo, int variadic_of
  * Note: The sql definition is STRICT so no input NULLs need to
  * be dealt with except for gtype.
  */
-PG_FUNCTION_INFO_V1(age_gtype_sum);
+PG_FUNCTION_INFO_V1(gtype_gtype_sum);
 
-Datum age_gtype_sum(PG_FUNCTION_ARGS)
+Datum gtype_gtype_sum(PG_FUNCTION_ARGS)
 {
     gtype *agt_arg0 = AG_GET_ARG_GTYPE_P(0);
     gtype *agt_arg1 = AG_GET_ARG_GTYPE_P(1);
@@ -4420,9 +4420,9 @@ static Datum float8_lerp(Datum lo, Datum hi, double pct)
 }
 
 /* Code borrowed and adjusted from PG's ordered_set_transition function */
-PG_FUNCTION_INFO_V1(age_percentile_aggtransfn);
+PG_FUNCTION_INFO_V1(gtype_percentile_aggtransfn);
 
-Datum age_percentile_aggtransfn(PG_FUNCTION_ARGS)
+Datum gtype_percentile_aggtransfn(PG_FUNCTION_ARGS)
 {
     PercentileGroupAggState *pgastate;
 
@@ -4486,9 +4486,9 @@ Datum age_percentile_aggtransfn(PG_FUNCTION_ARGS)
 }
 
 /* Code borrowed and adjusted from PG's percentile_cont_final function */
-PG_FUNCTION_INFO_V1(age_percentile_cont_aggfinalfn);
+PG_FUNCTION_INFO_V1(gtype_percentile_cont_aggfinalfn);
 
-Datum age_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
+Datum gtype_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
 {
     PercentileGroupAggState *pgastate;
     float8 percentile;
@@ -4563,9 +4563,9 @@ Datum age_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
 }
 
 /* Code borrowed and adjusted from PG's percentile_disc_final function */
-PG_FUNCTION_INFO_V1(age_percentile_disc_aggfinalfn);
+PG_FUNCTION_INFO_V1(gtype_percentile_disc_aggfinalfn);
 
-Datum age_percentile_disc_aggfinalfn(PG_FUNCTION_ARGS)
+Datum gtype_percentile_disc_aggfinalfn(PG_FUNCTION_ARGS)
 {
     PercentileGroupAggState *pgastate;
     double percentile;
@@ -4626,9 +4626,9 @@ Datum age_percentile_disc_aggfinalfn(PG_FUNCTION_ARGS)
 }
 
 /* functions to support the aggregate function COLLECT() */
-PG_FUNCTION_INFO_V1(age_collect_aggtransfn);
+PG_FUNCTION_INFO_V1(gtype_collect_aggtransfn);
 
-Datum age_collect_aggtransfn(PG_FUNCTION_ARGS)
+Datum gtype_collect_aggtransfn(PG_FUNCTION_ARGS)
 {
     gtype_in_state *castate;
     int nargs;
@@ -4696,9 +4696,9 @@ Datum age_collect_aggtransfn(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(castate);
 }
 
-PG_FUNCTION_INFO_V1(age_collect_aggfinalfn);
+PG_FUNCTION_INFO_V1(gtype_collect_aggfinalfn);
 
-Datum age_collect_aggfinalfn(PG_FUNCTION_ARGS) {
+Datum gtype_collect_aggfinalfn(PG_FUNCTION_ARGS) {
     gtype_in_state *castate;
     MemoryContext old_mcxt;
 
@@ -4769,11 +4769,11 @@ gtype_value *get_gtype_value(char *funcname, gtype *agt_arg,
     return agtv_value;
 }
 
-PG_FUNCTION_INFO_V1(age_eq_tilde);
+PG_FUNCTION_INFO_V1(gtype_eq_tilde);
 /*
  * function for =~ aka regular expression comparisons
  */
-Datum age_eq_tilde(PG_FUNCTION_ARGS)
+Datum gtype_eq_tilde(PG_FUNCTION_ARGS)
 {
     gtype *agt_string = AG_GET_ARG_GTYPE_P(0);
     gtype *agt_pattern = AG_GET_ARG_GTYPE_P(1);
@@ -4854,8 +4854,8 @@ static gtype_iterator *get_next_object_key(gtype_iterator *it, gtype_container *
     return it;
 }
 
-PG_FUNCTION_INFO_V1(age_vertex_keys);
-Datum age_vertex_keys(PG_FUNCTION_ARGS)
+PG_FUNCTION_INFO_V1(vertex_keys);
+Datum vertex_keys(PG_FUNCTION_ARGS)
 {
     gtype *agt_arg = NULL;
     gtype_value *agtv_result = NULL;
@@ -4880,8 +4880,8 @@ Datum age_vertex_keys(PG_FUNCTION_ARGS)
 }
 
 
-PG_FUNCTION_INFO_V1(age_edge_keys);
-Datum age_edge_keys(PG_FUNCTION_ARGS)
+PG_FUNCTION_INFO_V1(edge_keys);
+Datum edge_keys(PG_FUNCTION_ARGS)
 {   
     gtype *agt_arg = NULL;
     gtype_value *agtv_result = NULL;
@@ -4907,8 +4907,8 @@ Datum age_edge_keys(PG_FUNCTION_ARGS)
 
 
 
-PG_FUNCTION_INFO_V1(age_keys);
-Datum age_keys(PG_FUNCTION_ARGS)
+PG_FUNCTION_INFO_V1(gtype_keys);
+Datum gtype_keys(PG_FUNCTION_ARGS)
 {
     gtype *agt_arg = NULL;
     gtype_value *agtv_result = NULL;
@@ -4989,11 +4989,11 @@ static int64 get_int64_from_int_datums(Datum d, Oid type, char *funcname, bool *
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_range);
+PG_FUNCTION_INFO_V1(gtype_range);
 /*
  * Execution function to implement openCypher range() function
  */
-Datum age_range(PG_FUNCTION_ARGS)
+Datum gtype_range(PG_FUNCTION_ARGS)
 {
     Datum *args = NULL;
     bool *nulls = NULL;
@@ -5064,14 +5064,14 @@ Datum age_range(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(gtype_value_to_gtype(agis_result.res));
 }
 
-PG_FUNCTION_INFO_V1(age_unnest);
+PG_FUNCTION_INFO_V1(gtype_unnest);
 /*
  * Function to convert the Array type of Agtype into each row. It is used for
  * Cypher `UNWIND` clause, but considering the situation in which the user can
  * directly use this function in vanilla PGSQL, put a second parameter related
  * to this.
  */
-Datum age_unnest(PG_FUNCTION_ARGS)
+Datum gtype_unnest(PG_FUNCTION_ARGS)
 {
     gtype *gtype_arg = AG_GET_ARG_GTYPE_P(0);
     bool block_types = PG_GETARG_BOOL(1);

--- a/src/backend/utils/adt/gtype_typecasting.c
+++ b/src/backend/utils/adt/gtype_typecasting.c
@@ -110,9 +110,9 @@ gtype_tointeger(PG_FUNCTION_ARGS) {
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv));
 }
 
-PG_FUNCTION_INFO_V1(age_tofloat);
+PG_FUNCTION_INFO_V1(gtype_tofloat);
 Datum
-age_tofloat(PG_FUNCTION_ARGS) {
+gtype_tofloat(PG_FUNCTION_ARGS) {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
     if (is_gtype_null(agt))
@@ -129,10 +129,10 @@ age_tofloat(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(age_tonumeric);
+PG_FUNCTION_INFO_V1(gtype_tonumeric);
 // gtype -> gtype numeric
 Datum
-age_tonumeric(PG_FUNCTION_ARGS) {
+gtype_tonumeric(PG_FUNCTION_ARGS) {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
     if (is_gtype_null(agt))
@@ -147,9 +147,9 @@ age_tonumeric(PG_FUNCTION_ARGS) {
     PG_RETURN_POINTER(gtype_value_to_gtype(&agtv));
 }
 
-PG_FUNCTION_INFO_V1(age_tostring);
+PG_FUNCTION_INFO_V1(gtype_tostring);
 Datum
-age_tostring(PG_FUNCTION_ARGS) {
+gtype_tostring(PG_FUNCTION_ARGS) {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
     if (is_gtype_null(agt))
@@ -167,9 +167,9 @@ age_tostring(PG_FUNCTION_ARGS) {
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&agtv));
 }
 
-PG_FUNCTION_INFO_V1(age_totimestamp);
+PG_FUNCTION_INFO_V1(gtype_totimestamp);
 Datum
-age_totimestamp(PG_FUNCTION_ARGS) {
+gtype_totimestamp(PG_FUNCTION_ARGS) {
     gtype *agt = AG_GET_ARG_GTYPE_P(0);
 
     if (is_gtype_null(agt))

--- a/src/backend/utils/adt/vertex.c
+++ b/src/backend/utils/adt/vertex.c
@@ -332,10 +332,13 @@ Datum
 vertex_id(PG_FUNCTION_ARGS) {
     vertex *v = AG_GET_ARG_VERTEX(0);
 
-    AG_RETURN_GRAPHID((graphid)v->children[0]);
-}
+    gtype_value gtv = { .type = AGTV_INTEGER, .val = {.int_value = *((int64 *)(&v->children[0])) } };    
 
-PG_FUNCTION_INFO_V1(age_vertex_id);
+    AG_RETURN_GTYPE_P(gtype_value_to_gtype(&gtv));
+//    AG_RETURN_GRAPHID(*((int64 *)(&v->children[0])));
+}
+/*
+PG_FUNCTION_INFO_V1(gtype_vertex_id);
 Datum
 age_vertex_id(PG_FUNCTION_ARGS) {
     vertex *v = AG_GET_ARG_VERTEX(0);
@@ -344,8 +347,8 @@ age_vertex_id(PG_FUNCTION_ARGS) {
 
     AG_RETURN_GTYPE_P(gtype_value_to_gtype(&gtv));
 }
-
-
+*/
+/*
 PG_FUNCTION_INFO_V1(vertex_label);
 Datum
 vertex_label(PG_FUNCTION_ARGS) {
@@ -356,7 +359,7 @@ vertex_label(PG_FUNCTION_ARGS) {
 
     PG_RETURN_POINTER(d);
 }
-
+*/
 PG_FUNCTION_INFO_V1(vertex_properties);
 Datum
 vertex_properties(PG_FUNCTION_ARGS) {
@@ -365,9 +368,9 @@ vertex_properties(PG_FUNCTION_ARGS) {
     AG_RETURN_GTYPE_P(extract_vertex_properties(v));
 }
 
-PG_FUNCTION_INFO_V1(age_vertex_label);
+PG_FUNCTION_INFO_V1(vertex_label);
 Datum
-age_vertex_label(PG_FUNCTION_ARGS) {
+vertex_label(PG_FUNCTION_ARGS) {
     vertex *v = AG_GET_ARG_VERTEX(0);
 
     gtype_value gtv = {

--- a/src/backend/utils/path_finding/age_vle.c
+++ b/src/backend/utils/path_finding/age_vle.c
@@ -669,8 +669,8 @@ static path_container *build_path_container(path_finding_context *path_ctx) {
  *     6 - gtype REQUIRED edge direction (enum) as an integer. REQUIRED
  
 */
-PG_FUNCTION_INFO_V1(age_vle);
-Datum age_vle(PG_FUNCTION_ARGS) {
+PG_FUNCTION_INFO_V1(gtype_vle);
+Datum gtype_vle(PG_FUNCTION_ARGS) {
     FuncCallContext *funcctx;
     bool found_a_path;
     MemoryContext oldctx;

--- a/src/include/commands/label_commands.h
+++ b/src/include/commands/label_commands.h
@@ -31,20 +31,20 @@
 #define AG_VERTEX_COLNAME_ID "id"
 #define AG_VERTEX_COLNAME_PROPERTIES "properties"
 
-#define AG_ACCESS_FUNCTION_ID "age_id"
+#define AG_ACCESS_FUNCTION_ID "id"
 
-#define AG_VERTEX_ACCESS_FUNCTION_ID "age_id"
-#define AG_VERTEX_ACCESS_FUNCTION_PROPERTIES "age_properties"
+#define AG_VERTEX_ACCESS_FUNCTION_ID "id"
+#define AG_VERTEX_ACCESS_FUNCTION_PROPERTIES "properties"
 
 #define AG_EDGE_COLNAME_ID "id"
 #define AG_EDGE_COLNAME_START_ID "start_id"
 #define AG_EDGE_COLNAME_END_ID "end_id"
 #define AG_EDGE_COLNAME_PROPERTIES "properties"
 
-#define AG_EDGE_ACCESS_FUNCTION_ID "age_id"
-#define AG_EDGE_ACCESS_FUNCTION_START_ID "age_start_id"
-#define AG_EDGE_ACCESS_FUNCTION_END_ID "age_end_id"
-#define AG_EDGE_ACCESS_FUNCTION_PROPERTIES "age_properties"
+#define AG_EDGE_ACCESS_FUNCTION_ID "id"
+#define AG_EDGE_ACCESS_FUNCTION_START_ID "start_id"
+#define AG_EDGE_ACCESS_FUNCTION_END_ID "end_id"
+#define AG_EDGE_ACCESS_FUNCTION_PROPERTIES "properties"
 
 #define IS_DEFAULT_LABEL_EDGE(str) \
     (str != NULL && strcmp(AG_DEFAULT_LABEL_EDGE, str) == 0)


### PR DESCRIPTION
Removed the age prefix before function names. this gives better error messages and type safety.