### PR TITLE
Removed gtype_network.o from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ OBJS = src/backend/postgraph.o \
        src/backend/utils/adt/gtype.o \
        src/backend/utils/adt/gtype_ext.o \
        src/backend/utils/adt/gtype_gin.o \
-       src/backend/utils/adt/gtype_network.o \
        src/backend/utils/adt/gtype_ops.o \
        src/backend/utils/adt/gtype_parser.o \
        src/backend/utils/adt/gtype_temporal.o \


### PR DESCRIPTION
Executing the `make install` command now works. 

It wasn't working before because there was no file named `gtype_network.c` under `src/backend/utils/adt/`.

This PR solves issue #358 